### PR TITLE
Updating State Machine to be stack-based.

### DIFF
--- a/CS483/CS483/CS483.vcxproj
+++ b/CS483/CS483/CS483.vcxproj
@@ -44,7 +44,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>false</SDLCheck>
-      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\HeatStroke\Transform;$(ProjectDir)\..\..\HeatStroke\StateMachine;$(ProjectDir)\..\..\HeatStroke\Services\XML;$(ProjectDir)\..\..\HeatStroke\Services\IO;$(ProjectDir)\..\..\HeatStroke\Services\GameObjectManager;$(ProjectDir)\..\..\HeatStroke\Services\Events;$(ProjectDir)\..\..\HeatStroke\Services;$(ProjectDir)\..\..\HeatStroke\SceneManagement;$(ProjectDir)\..\..\HeatStroke\Graphics\Texture;$(ProjectDir)\..\..\HeatStroke\Graphics\Shaders;$(ProjectDir)\..\..\HeatStroke\Graphics\Scene;$(ProjectDir)\..\..\HeatStroke\Graphics\Renderable;$(ProjectDir)\..\..\HeatStroke\Graphics\Program;$(ProjectDir)\..\..\HeatStroke\Graphics\Material;$(ProjectDir)\..\..\HeatStroke\Graphics\GDebug;$(ProjectDir)\..\..\HeatStroke\Graphics\Common;$(ProjectDir)\..\..\HeatStroke\Graphics\Buffer;$(ProjectDir)\..\..\HeatStroke\GOComponents\Components;$(ProjectDir)\..\..\HeatStroke\GOComponents;$(ProjectDir)\..\..\HeatStroke\Geometry;$(ProjectDir)\..\..\HeatStroke\Common;$(ProjectDir)\..\..\FreeImage3170\FreeImage\Dist\x32;$(ProjectDir)\..\..\tinyxml2;$(ProjectDir)\..\..\glm-0.9.7.2\glm;$(ProjectDir)\..\..\glfw-3.1.2.bin.WIN32\include;$(ProjectDir)\..\..\glew-1.13.0\include;$(ProjectDir)\..\..\boost_1_60_0</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\HeatStroke\Transform;$(ProjectDir)\..\..\HeatStroke\StateMachine;$(ProjectDir)\..\..\HeatStroke\Services\XML;$(ProjectDir)\..\..\HeatStroke\Services\IO;$(ProjectDir)\..\..\HeatStroke\Services\GameObjectManager;$(ProjectDir)\..\..\HeatStroke\Services\Events;$(ProjectDir)\..\..\HeatStroke\Services;$(ProjectDir)\..\..\HeatStroke\SceneManagement;$(ProjectDir)\..\..\HeatStroke\Graphics\Texture;$(ProjectDir)\..\..\HeatStroke\Graphics\Shaders;$(ProjectDir)\..\..\HeatStroke\Graphics\Scene;$(ProjectDir)\..\..\HeatStroke\Graphics\Renderable;$(ProjectDir)\..\..\HeatStroke\Graphics\Program;$(ProjectDir)\..\..\HeatStroke\Graphics\Material;$(ProjectDir)\..\..\HeatStroke\Graphics\GDebug;$(ProjectDir)\..\..\HeatStroke\Graphics\Common;$(ProjectDir)\..\..\HeatStroke\Graphics\Buffer;$(ProjectDir)\..\..\HeatStroke\GOComponents\Components;$(ProjectDir)\..\..\HeatStroke\GOComponents;$(ProjectDir)\..\..\HeatStroke\Geometry;$(ProjectDir)\..\..\HeatStroke\Common;$(ProjectDir)\..\..\FreeImage3170\FreeImage\Dist\x32;$(ProjectDir)\..\..\tinyxml2;$(ProjectDir)\..\..\glm-0.9.7.2\glm;$(ProjectDir)\..\..\glfw-3.1.2.bin.WIN32\include;$(ProjectDir)\..\..\glew-1.13.0\include;$(ProjectDir)\..\..\boost_1_60_0;$(ProjectDir)\..\..\Kartaclysm\StateMachine\Gameplay</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_CONSOLE;GLEW_STATIC;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
@@ -108,7 +108,9 @@
     <ClCompile Include="..\..\HeatStroke\StateMachine\StateMachine.cpp" />
     <ClCompile Include="..\..\HeatStroke\Transform\HierarchicalTransform.cpp" />
     <ClCompile Include="..\..\HeatStroke\Transform\Transform.cpp" />
-    <ClCompile Include="Kartaclysm\main.cpp" />
+    <ClCompile Include="..\..\Kartaclysm\KartGame.cpp" />
+    <ClCompile Include="..\..\Kartaclysm\main.cpp" />
+    <ClCompile Include="..\..\Kartaclysm\StateMachine\Gameplay\StateRacing.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\HeatStroke\Common\Common.h" />
@@ -157,6 +159,9 @@
     <ClInclude Include="..\..\HeatStroke\StateMachine\StateMachine.h" />
     <ClInclude Include="..\..\HeatStroke\Transform\HierarchicalTransform.h" />
     <ClInclude Include="..\..\HeatStroke\Transform\Transform.h" />
+    <ClInclude Include="..\..\Kartaclysm\KartGame.h" />
+    <ClInclude Include="..\..\Kartaclysm\StateMachine\Gameplay\GameplayState.h" />
+    <ClInclude Include="..\..\Kartaclysm\StateMachine\Gameplay\StateRacing.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/CS483/CS483/CS483.vcxproj.filters
+++ b/CS483/CS483/CS483.vcxproj.filters
@@ -73,6 +73,12 @@
     <Filter Include="HeatStroke\Graphics\GDebug">
       <UniqueIdentifier>{2c5b1998-510b-4154-bee1-e907c671be12}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Kartaclysm\StateMachine">
+      <UniqueIdentifier>{cd1c30ac-a893-447c-95a9-07196de33662}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Kartaclysm\StateMachine\Gameplay">
+      <UniqueIdentifier>{11fb4673-e684-4054-a1a3-2d8759f10f62}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\HeatStroke\Services\IO\KeyboardInputBuffer.cpp">
@@ -177,14 +183,20 @@
     <ClCompile Include="..\..\HeatStroke\SceneManagement\ScenePointLight.cpp">
       <Filter>HeatStroke\SceneManagement</Filter>
     </ClCompile>
-    <ClCompile Include="Kartaclysm\main.cpp">
-      <Filter>Kartaclysm</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\HeatStroke\Common\Common.cpp">
       <Filter>HeatStroke\Common</Filter>
     </ClCompile>
     <ClCompile Include="..\..\HeatStroke\Graphics\GDebug\LineDrawer.cpp">
       <Filter>HeatStroke\Graphics\GDebug</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Kartaclysm\KartGame.cpp">
+      <Filter>Kartaclysm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Kartaclysm\main.cpp">
+      <Filter>Kartaclysm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Kartaclysm\StateMachine\Gameplay\StateRacing.cpp">
+      <Filter>Kartaclysm\StateMachine\Gameplay</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -325,6 +337,15 @@
     </ClInclude>
     <ClInclude Include="..\..\HeatStroke\Graphics\GDebug\LineDrawer.h">
       <Filter>HeatStroke\Graphics\GDebug</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Kartaclysm\KartGame.h">
+      <Filter>Kartaclysm</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Kartaclysm\StateMachine\Gameplay\GameplayState.h">
+      <Filter>Kartaclysm\StateMachine\Gameplay</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Kartaclysm\StateMachine\Gameplay\StateRacing.h">
+      <Filter>Kartaclysm\StateMachine\Gameplay</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/HeatStroke/StateMachine/State.h
+++ b/HeatStroke/StateMachine/State.h
@@ -22,8 +22,8 @@ namespace HeatStroke
 			
 		// Required interface for all subclasses.
 		virtual void Enter(const std::map<std::string, std::string>& p_mContextParameters) = 0;
-		virtual void Suspend() = 0; // pushed down in stack
-		virtual void Unsuspend() = 0; // popped back to top in stack
+		virtual void Suspend(const int p_iNewState) = 0;
+		virtual void Unsuspend(const int p_iPrevState) = 0;
 		virtual void Update(const float p_fDelta) = 0;
 		virtual void Exit() = 0;
 

--- a/HeatStroke/StateMachine/State.h
+++ b/HeatStroke/StateMachine/State.h
@@ -22,6 +22,8 @@ namespace HeatStroke
 			
 		// Required interface for all subclasses.
 		virtual void Enter(const std::map<std::string, std::string>& p_mContextParameters) = 0;
+		virtual void Suspend() = 0; // pushed down in stack
+		virtual void Unsuspend() = 0; // popped back to top in stack
 		virtual void Update(const float p_fDelta) = 0;
 		virtual void Exit() = 0;
 

--- a/HeatStroke/StateMachine/StateMachine.cpp
+++ b/HeatStroke/StateMachine/StateMachine.cpp
@@ -7,52 +7,90 @@
 
 #include "StateMachine.h"
 
+//------------------------------------------------------------------------------
+// Method:    StateMachine
+// 
+// Constructor
+//------------------------------------------------------------------------------
 HeatStroke::StateMachine::StateMachine()
 	:
-	m_iCurrentState(-1),
-	m_pCurrentState(nullptr),
+	m_mCurrentState(-1, nullptr),
 	m_fCurrentStateTime(0.0f),
 	m_pOwner(nullptr)
 {
 }
 
-
+//------------------------------------------------------------------------------
+// Method:    ~StateMachine
+// 
+// Destructor. Calls Exit() on stack and deletes all registered states.
+//------------------------------------------------------------------------------
 HeatStroke::StateMachine::~StateMachine()
 {
-	// Call exit on every state in stack
-	PopToTop();
-	Pop();
+	// Call Exit() on every state in stack
+	while (!m_mStateStack.empty() && m_mCurrentState.second != nullptr)
+	{
+		Pop();
+	}
+
+	// Delete all registered states
+	StateMap::iterator it = m_mStateMap.begin();
+	while (it != m_mStateMap.end())
+	{
+		if (it->second != nullptr)
+		{
+			delete it->second;
+			it->second = nullptr;
+		}
+
+		it = m_mStateMap.erase(it);
+	}
 }
 
-
+//------------------------------------------------------------------------------
+// Method:		RegisterState
+// Parameter:	int p_iState - index to map state
+//				State* p_pState - state to register to index
+// 
+// Register a state to an index. Ownership of the state now belongs to this state machine.
+//------------------------------------------------------------------------------
 void HeatStroke::StateMachine::RegisterState(int p_iState, State* p_pState)
 {
 	p_pState->SetStateMachineMembership(this);
-	m_mStateMap.insert(std::pair<int, State*>(p_iState, p_pState));
+	m_mStateMap.insert(StateMap::value_type(p_iState, p_pState));
 }
 
-
-void HeatStroke::StateMachine::Push(int p_iState, ContextParameters p_mContextParameters)
+//------------------------------------------------------------------------------
+// Method:		Push
+// Parameter:	int p_iState - integer of state to push
+//				const ContextParameters& p_mContextParameters - Context parameters for State
+// 
+// Pushes state mapped to index on top of stack, and calls Enter() with context parameters
+// Calls Suspend() on current state on top of the stack
+// Asserts that the same state is not on the stack twice
+//------------------------------------------------------------------------------
+void HeatStroke::StateMachine::Push(int p_iState, const ContextParameters& p_mContextParameters)
 {
-	// Prevent double entering current state
-	if (p_iState == m_iCurrentState)
+	// Prevent a state from being on the stack twice
+	StateStack::iterator it = m_mStateStack.begin(), end = m_mStateStack.end();
+	for (; it != end; it++)
 	{
-		return;
+		assert(it->first != p_iState);
 	}
 
 	// Find state mapped to index
 	State* pState = nullptr;
-	StateMap::iterator it = m_mStateMap.find(p_iState);
-	if (it != m_mStateMap.end())
+	StateMap::iterator it2 = m_mStateMap.find(p_iState);
+	if (it2 != m_mStateMap.end())
 	{
-		pState = static_cast<State*>(it->second);
+		pState = static_cast<State*>(it2->second);
 	}
 	assert(pState != nullptr);
 
 	// Call Suspend() on current state if it exists
-	if (m_pCurrentState != nullptr)
+	if (m_mCurrentState.second != nullptr)
 	{
-		m_pCurrentState->Suspend();
+		m_mCurrentState.second->Suspend(it2->first);
 	}
 
 	// Push and enter new state
@@ -60,71 +98,71 @@ void HeatStroke::StateMachine::Push(int p_iState, ContextParameters p_mContextPa
 	pState->Enter(p_mContextParameters);
 
 	// Set the new current state info
-	m_iCurrentState = p_iState;
-	m_pCurrentState = pState;
+	m_mCurrentState.first = p_iState;
+	m_mCurrentState.second = pState;
 	m_fCurrentStateTime = 0.0f;
 }
 
-void HeatStroke::StateMachine::Pop()
+//------------------------------------------------------------------------------
+// Method:	Pop
+// Returns:	StatePair
+// 
+// Calls Exit() on state, pops it off to return, and unsuspends next state on stack
+//------------------------------------------------------------------------------
+HeatStroke::StateMachine::StatePair HeatStroke::StateMachine::Pop()
 {
+	StatePair mReturn = m_mCurrentState;
 	if (!m_mStateStack.empty())
 	{
 		// Exit and pop current state
-		m_pCurrentState->Exit();
+		assert(m_mCurrentState.second != nullptr);
+		m_mCurrentState.second->Exit();
 		m_mStateStack.pop_back();
 
 		// Set the new current state info and call Unsuspend() on new state if it exists
 		m_fCurrentStateTime = 0.0f;
 		if (m_mStateStack.empty())
 		{
-			m_iCurrentState = -1;
-			m_pCurrentState = nullptr;
+			m_mCurrentState.first = -1;
+			m_mCurrentState.second = nullptr;
 		}
 		else
 		{
-			m_iCurrentState = m_mStateStack.back().first;
-			m_pCurrentState = static_cast<State*>(m_mStateStack.back().second);
-			m_pCurrentState->Unsuspend();
+			m_mCurrentState.first = m_mStateStack.back().first;
+			m_mCurrentState.second = static_cast<State*>(m_mStateStack.back().second);
+			m_mCurrentState.second->Unsuspend(mReturn.first);
 		}
 	}
+
+	return mReturn;
 }
 
-
-void HeatStroke::StateMachine::PopAndPush(int p_iState, ContextParameters p_mContextParameters)
+//------------------------------------------------------------------------------
+// Method:		Update
+// Parameter:	const float p_fDelta
+//				const bool m_bUpdateStack - update entire stack (true) or current state (false)
+// 
+// Update either the entire stack or just the top state on the stack
+//------------------------------------------------------------------------------
+void HeatStroke::StateMachine::Update(const float p_fDelta, const bool m_bUpdateStack)
 {
-	Pop();
-	Push(p_iState, p_mContextParameters);
-}
-
-
-void HeatStroke::StateMachine::PopToTop()
-{
-	while (m_mStateStack.size() > 1)
-	{
-		Pop();
-	}
-}
-
-
-void HeatStroke::StateMachine::PopToTopAndPush(int p_iState, ContextParameters p_mContextParameters)
-{
-	PopToTop();
-	Push(p_iState, p_mContextParameters);
-}
-
-
-void HeatStroke::StateMachine::PopAllAndPush(int p_iState, ContextParameters p_mContextParameters)
-{
-	PopToTop();
-	PopAndPush(p_iState, p_mContextParameters);
-}
-
-
-void HeatStroke::StateMachine::Update(float p_fDelta)
-{
+	// TO DO, should each state have an independent tracker for how long it has been in the stack?
 	m_fCurrentStateTime += p_fDelta;
-	if (m_pCurrentState)
+	if (m_bUpdateStack)
 	{
-		m_pCurrentState->Update(p_fDelta);
+		// Update entire stack from bottom to top
+		StateStack::iterator it = m_mStateStack.begin(), end = m_mStateStack.end();
+		for (; it != end; it++)
+		{
+			it->second->Update(p_fDelta);
+		}
+	}
+	else
+	{
+		// Update only the top state
+		if (m_mCurrentState.second != nullptr)
+		{
+			m_mCurrentState.second->Update(p_fDelta);
+		}
 	}
 }

--- a/HeatStroke/StateMachine/StateMachine.cpp
+++ b/HeatStroke/StateMachine/StateMachine.cpp
@@ -19,6 +19,9 @@ HeatStroke::StateMachine::StateMachine()
 
 HeatStroke::StateMachine::~StateMachine()
 {
+	// Call exit on every state in stack
+	PopToTop();
+	Pop();
 }
 
 
@@ -29,7 +32,7 @@ void HeatStroke::StateMachine::RegisterState(int p_iState, State* p_pState)
 }
 
 
-void HeatStroke::StateMachine::GoToState(int p_iState, const std::map<std::string, std::string>& p_mContextParameters)
+void HeatStroke::StateMachine::Push(int p_iState, ContextParameters p_mContextParameters)
 {
 	// Prevent double entering current state
 	if (p_iState == m_iCurrentState)
@@ -37,6 +40,7 @@ void HeatStroke::StateMachine::GoToState(int p_iState, const std::map<std::strin
 		return;
 	}
 
+	// Find state mapped to index
 	State* pState = nullptr;
 	StateMap::iterator it = m_mStateMap.find(p_iState);
 	if (it != m_mStateMap.end())
@@ -45,20 +49,76 @@ void HeatStroke::StateMachine::GoToState(int p_iState, const std::map<std::strin
 	}
 	assert(pState != nullptr);
 
-	// Call exit on current state
-	if (m_pCurrentState)
+	// Call Suspend() on current state if it exists
+	if (m_pCurrentState != nullptr)
 	{
-		m_pCurrentState->Exit();
+		m_pCurrentState->Suspend();
 	}
 
-	// Call enter on the new state
+	// Push and enter new state
+	m_mStateStack.push_back(std::pair<int, State*>(p_iState, pState));
 	pState->Enter(p_mContextParameters);
 
-	// Set the new current state.
+	// Set the new current state info
 	m_iCurrentState = p_iState;
 	m_pCurrentState = pState;
 	m_fCurrentStateTime = 0.0f;
 }
+
+void HeatStroke::StateMachine::Pop()
+{
+	if (!m_mStateStack.empty())
+	{
+		// Exit and pop current state
+		m_pCurrentState->Exit();
+		m_mStateStack.pop_back();
+
+		// Set the new current state info and call Unsuspend() on new state if it exists
+		m_fCurrentStateTime = 0.0f;
+		if (m_mStateStack.empty())
+		{
+			m_iCurrentState = -1;
+			m_pCurrentState = nullptr;
+		}
+		else
+		{
+			m_iCurrentState = m_mStateStack.back().first;
+			m_pCurrentState = static_cast<State*>(m_mStateStack.back().second);
+			m_pCurrentState->Unsuspend();
+		}
+	}
+}
+
+
+void HeatStroke::StateMachine::PopAndPush(int p_iState, ContextParameters p_mContextParameters)
+{
+	Pop();
+	Push(p_iState, p_mContextParameters);
+}
+
+
+void HeatStroke::StateMachine::PopToTop()
+{
+	while (m_mStateStack.size() > 1)
+	{
+		Pop();
+	}
+}
+
+
+void HeatStroke::StateMachine::PopToTopAndPush(int p_iState, ContextParameters p_mContextParameters)
+{
+	PopToTop();
+	Push(p_iState, p_mContextParameters);
+}
+
+
+void HeatStroke::StateMachine::PopAllAndPush(int p_iState, ContextParameters p_mContextParameters)
+{
+	PopToTop();
+	PopAndPush(p_iState, p_mContextParameters);
+}
+
 
 void HeatStroke::StateMachine::Update(float p_fDelta)
 {

--- a/HeatStroke/StateMachine/StateMachine.h
+++ b/HeatStroke/StateMachine/StateMachine.h
@@ -5,8 +5,8 @@
 // State machine that manages state transitions.
 //------------------------------------------------------------------------
 
-#ifndef STATEMACHINE_H
-#define STATEMACHINE_H
+#ifndef STATE_MACHINE_H
+#define STATE_MACHINE_H
 
 #include <map>
 #include <vector>
@@ -18,28 +18,32 @@ namespace HeatStroke
 {
 	class StateMachine
 	{
-		typedef std::map<int, State*> StateMap;
-		typedef std::vector<std::pair<int, State*>> StateStack;
-		typedef const std::map<std::string, std::string>& ContextParameters;
-
 	public:
-		StateMachine(void);
-		~StateMachine(void);
+		// convenient typedefs
+		typedef std::map<int, State*> StateMap;
+		typedef std::pair<int, State*> StatePair;
+		typedef std::vector<StatePair> StateStack;
+		typedef std::map<std::string, std::string> ContextParameters;
+
+		//------------------------------------------------------------------------------
+		// Public methods.
+		//------------------------------------------------------------------------------
+		StateMachine();
+		~StateMachine();
 
 		void RegisterState(int p_iState, State* p_pstate);
-		void Push(int p_iState, ContextParameters p_mContextParameters);
-		void Pop();
-		void PopAndPush(int p_iState, ContextParameters p_mContextParameters);
-		void PopToTop();
-		void PopToTopAndPush(int p_iState, ContextParameters p_mContextParameters);
-		void PopAllAndPush(int p_iState, ContextParameters p_mContextParameters);
 
-		void Update(const float p_fDelta);
+		// Stack-based mechanics
+		void Push(int p_iState, const ContextParameters& p_mContextParameters = ContextParameters());
+		StatePair Pop();
+		const StatePair& Peek() const				{ return m_mCurrentState; }
+		StateStack::const_iterator begin()			{ return m_mStateStack.begin(); }
+		StateStack::const_iterator end()			{ return m_mStateStack.end(); }
+		bool empty() const							{ return m_mStateStack.empty(); }
 
-		int GetCurrentState()					{ return m_iCurrentState; }
-		float GetCurrentStateTime()				{ return m_fCurrentStateTime; }
-		StateStack::const_iterator StackBegin()	{ return m_mStateStack.begin(); }
-		StateStack::const_iterator StackEnd()	{ return m_mStateStack.end(); }
+		void Update(const float p_fDelta, const bool m_bUpdateStack = false);
+
+		float GetCurrentStateTime()					{ return m_fCurrentStateTime; }
 
 		// A way for states in a state machine to reference back to their owner
 		void SetStateMachineOwner(void *p_pOwner)	{ m_pOwner = p_pOwner; }
@@ -53,8 +57,7 @@ namespace HeatStroke
 		StateStack m_mStateStack;
 
 		// Current state
-		int m_iCurrentState;
-		State* m_pCurrentState;
+		StatePair m_mCurrentState;
 
 		// State timer
 		float m_fCurrentStateTime;
@@ -64,5 +67,5 @@ namespace HeatStroke
 	};
 } // namespace HeatStroke
 
-#endif // STATEMACHINE_H
+#endif // STATE_MACHINE_H
 

--- a/HeatStroke/StateMachine/StateMachine.h
+++ b/HeatStroke/StateMachine/StateMachine.h
@@ -8,6 +8,8 @@
 #ifndef STATEMACHINE_H
 #define STATEMACHINE_H
 
+#include <map>
+#include <vector>
 #include "State.h"
 
 #include <assert.h>
@@ -17,27 +19,38 @@ namespace HeatStroke
 	class StateMachine
 	{
 		typedef std::map<int, State*> StateMap;
+		typedef std::vector<std::pair<int, State*>> StateStack;
+		typedef const std::map<std::string, std::string>& ContextParameters;
 
 	public:
 		StateMachine(void);
 		~StateMachine(void);
 
 		void RegisterState(int p_iState, State* p_pstate);
-		void GoToState(int p_iState, const std::map<std::string, std::string>& p_mContextParameters);
+		void Push(int p_iState, ContextParameters p_mContextParameters);
+		void Pop();
+		void PopAndPush(int p_iState, ContextParameters p_mContextParameters);
+		void PopToTop();
+		void PopToTopAndPush(int p_iState, ContextParameters p_mContextParameters);
+		void PopAllAndPush(int p_iState, ContextParameters p_mContextParameters);
 
-		void Update(float p_fDelta);
+		void Update(const float p_fDelta);
 
-		int GetCurrentState()		{ return m_iCurrentState; }
-		float GetCurrentStateTime() { return m_fCurrentStateTime; }
+		int GetCurrentState()					{ return m_iCurrentState; }
+		float GetCurrentStateTime()				{ return m_fCurrentStateTime; }
+		StateStack::const_iterator StackBegin()	{ return m_mStateStack.begin(); }
+		StateStack::const_iterator StackEnd()	{ return m_mStateStack.end(); }
 
-		// A way for states in a state machine to reference back to their owner, whether 
-		// it's the Game class, a Character controller or an AI controller.
+		// A way for states in a state machine to reference back to their owner
 		void SetStateMachineOwner(void *p_pOwner)	{ m_pOwner = p_pOwner; }
 		void* GetStateMachineOwner()				{ return m_pOwner; }
 
 	private:
 		// Map of state Ids to state instances
 		StateMap m_mStateMap;
+
+		// Stack of current states
+		StateStack m_mStateStack;
 
 		// Current state
 		int m_iCurrentState;

--- a/Kartaclysm/KartGame.cpp
+++ b/Kartaclysm/KartGame.cpp
@@ -1,0 +1,50 @@
+//----------------------------------------------------------------------------
+// KartGame.cpp
+// Author: David MacIntosh
+//
+// Class that handles core game logic.
+//----------------------------------------------------------------------------
+
+#include "KartGame.h"
+
+bool Kartaclysm::KartGame::Init()
+{
+	// Initialize singletons
+	HeatStroke::KeyboardInputBuffer::CreateInstance(m_pWindow);
+
+	// Setup State Machine and push first state
+	m_pGameStates = new HeatStroke::StateMachine();
+	m_pGameStates->SetStateMachineOwner(this);
+	m_pGameStates->RegisterState(0, new StateRacing());
+	m_pGameStates->Push(0);
+
+	return true;
+}
+
+void Kartaclysm::KartGame::Update(const float p_fDelta)
+{
+	HeatStroke::KeyboardInputBuffer::Instance()->Update(p_fDelta);
+
+	// Call Update() on each state in stack, starting from bottom
+	m_pGameStates->Update(p_fDelta, true);
+}
+
+void Kartaclysm::KartGame::PreRender()
+{
+	// Call PreRender() on each state in stack, starting from bottom
+	auto it = m_pGameStates->begin(), end = m_pGameStates->end();
+	for (; it != end; it++)
+	{
+		static_cast<GameplayState*>(it->second)->PreRender();
+	}
+}
+
+void Kartaclysm::KartGame::Render()
+{
+}
+
+void Kartaclysm::KartGame::Shutdown()
+{
+	delete m_pGameStates;
+	m_pGameStates = nullptr;
+}

--- a/Kartaclysm/KartGame.h
+++ b/Kartaclysm/KartGame.h
@@ -1,0 +1,44 @@
+//----------------------------------------------------------------------------
+// KartGame.h
+// Author: David MacIntosh
+//
+// Class that handles core game logic.
+//----------------------------------------------------------------------------
+
+#ifndef KART_GAME_H
+#define KART_GAME_H
+
+#include "Game.h"
+#include "KeyboardInputBuffer.h"
+#include "StateMachine.h"
+#include "GameplayState.h"
+#include "StateRacing.h"
+
+namespace Kartaclysm
+{
+	class KartGame : public HeatStroke::Game
+	{
+	public:
+		KartGame() {}
+		~KartGame() {}
+		
+	private:
+		//--------------------------------------------------------------------------
+		// Private methods
+		//--------------------------------------------------------------------------
+		
+		bool Init();
+		void Update(const float p_fDelta);
+		void PreRender();
+		void Render();
+		void Shutdown();
+
+		//--------------------------------------------------------------------------
+		// Private variables
+		//--------------------------------------------------------------------------
+		// State machine to hold game states
+		HeatStroke::StateMachine* m_pGameStates;
+	};
+} // namespace Kartaclysm
+
+#endif // KART_GAME_H

--- a/Kartaclysm/StateMachine/Gameplay/GameplayState.h
+++ b/Kartaclysm/StateMachine/Gameplay/GameplayState.h
@@ -1,0 +1,42 @@
+//------------------------------------------------------------------------
+// GameplayState
+// Author:	Bradley Cooper
+//	
+// Base class for any gameplay state, extending from a regular state.
+//------------------------------------------------------------------------
+
+#ifndef GAMEPLAY_STATE_H
+#define GAMEPLAY_STATE_H
+
+#include "State.h"
+#include "GameObjectManager.h"
+
+namespace Kartaclysm
+{
+	class GameplayState : public HeatStroke::State
+	{
+	public:
+		GameplayState() : m_pGameObjectManager(nullptr) {}
+		virtual ~GameplayState() {}
+
+		// Inherited
+		virtual void Enter(const std::map<std::string, std::string>& p_mContextParameters) = 0;
+		virtual void Suspend(const int p_iNewState) = 0;
+		virtual void Unsuspend(const int p_iPrevState) = 0;
+		virtual void Update(const float p_fDelta) = 0;
+		virtual void Exit() = 0;
+
+		// Required interface for all subclasses
+		virtual void PreRender() = 0;
+
+	protected:
+		// Game Object Manager for this state
+		HeatStroke::GameObjectManager* m_pGameObjectManager;
+
+		// Update and render based on suspension status
+		bool m_bSuspended;
+	};
+} // namespace Kartaclysm
+
+#endif
+

--- a/Kartaclysm/StateMachine/Gameplay/StateRacing.cpp
+++ b/Kartaclysm/StateMachine/Gameplay/StateRacing.cpp
@@ -1,0 +1,117 @@
+//------------------------------------------------------------------------
+// StateRacing
+// Author:	Bradley Cooper
+//	
+// Gameplay state for racing.
+//------------------------------------------------------------------------
+
+#include "StateRacing.h"
+
+//------------------------------------------------------------------------------
+// Method:    StateRacing
+// Returns:   
+// 
+// Constructor.
+//------------------------------------------------------------------------------
+Kartaclysm::StateRacing::StateRacing()
+	:
+	m_pGameObjectManager(nullptr),
+	m_bSuspended(true)
+{
+}
+
+//------------------------------------------------------------------------------
+// Method:    ~StateRacing
+// Returns:   
+// 
+// Destructor.
+//------------------------------------------------------------------------------
+Kartaclysm::StateRacing::~StateRacing()
+{
+	Exit();
+}
+
+//------------------------------------------------------------------------------
+// Method:		Enter
+// Parameter:	std::map<std::string, std::string> p_mContextParameters - parameters for state
+// 
+// Called when this state is pushed onto the stack.
+//------------------------------------------------------------------------------
+void Kartaclysm::StateRacing::Enter(const std::map<std::string, std::string>& p_mContextParameters)
+{
+	m_bSuspended = true;
+
+	// Initialize our GameObjectManager
+	m_pGameObjectManager = new HeatStroke::GameObjectManager();
+
+	// Register component factory methods
+
+	// Handle passed context parameters
+
+	// Load XML to create GameObjects
+	
+}
+
+//------------------------------------------------------------------------------
+// Method:		Suspend
+// Parameter:	const int p_iNewState - index of new state being pushed
+// 
+// Called when this state is pushed down in the stack.
+//------------------------------------------------------------------------------
+void Kartaclysm::StateRacing::Suspend(const int p_iNewState)
+{
+	m_bSuspended = true;
+}
+
+//------------------------------------------------------------------------------
+// Method:		Unsuspend
+// Parameter:	const int p_iPrevState - index of previous state popped
+// 
+// Called when this state is popped back to top of stack.
+//------------------------------------------------------------------------------
+void Kartaclysm::StateRacing::Unsuspend(const int p_iPrevState)
+{
+	m_bSuspended = false;
+}
+
+//------------------------------------------------------------------------------
+// Method:    Update
+// Parameter: const float p_fDelta
+// 
+// Called each from when this state is active.
+//------------------------------------------------------------------------------
+void Kartaclysm::StateRacing::Update(const float p_fDelta)
+{
+	// Do not update when suspended
+	if (!m_bSuspended)
+	{
+		m_pGameObjectManager->Update(p_fDelta);
+	}
+}
+
+//------------------------------------------------------------------------------
+// Method:    PreRender
+// 
+// Called before rendering occurs.
+//------------------------------------------------------------------------------
+void Kartaclysm::StateRacing::PreRender()
+{
+	// Render even when suspended
+	m_pGameObjectManager->PreRender();
+}
+
+//------------------------------------------------------------------------------
+// Method:    Exit
+// 
+// Called when this state is popped off the stack.
+//------------------------------------------------------------------------------
+void Kartaclysm::StateRacing::Exit()
+{
+	m_bSuspended = false;
+	if (m_pGameObjectManager != nullptr)
+	{
+		m_pGameObjectManager->DestroyAllGameObjects();
+		delete m_pGameObjectManager;
+		m_pGameObjectManager = nullptr;
+	}
+}

--- a/Kartaclysm/StateMachine/Gameplay/StateRacing.h
+++ b/Kartaclysm/StateMachine/Gameplay/StateRacing.h
@@ -1,0 +1,40 @@
+//------------------------------------------------------------------------
+// StateRacing
+// Author:	Bradley Cooper
+//	
+// Gameplay state for racing.
+//------------------------------------------------------------------------
+
+#ifndef STATE_RACING_H
+#define STATE_RACING_H
+
+#include "GameplayState.h"
+
+namespace Kartaclysm
+{
+	class StateRacing : public Kartaclysm::GameplayState
+	{
+	public:
+		//------------------------------------------------------------------------------
+		// Public methods.
+		//------------------------------------------------------------------------------
+		StateRacing();
+		virtual ~StateRacing();
+
+		// Inherited
+		void Enter(const std::map<std::string, std::string>& p_mContextParameters);
+		void Suspend(const int p_iNewState);
+		void Unsuspend(const int p_iPrevState);
+		void Update(const float p_fDelta);
+		void PreRender();
+		void Exit();
+
+	protected:
+		// Inherited
+		HeatStroke::GameObjectManager* m_pGameObjectManager;
+		bool m_bSuspended;
+	};
+} // namespace Kartaclysm
+
+#endif
+

--- a/Kartaclysm/main.cpp
+++ b/Kartaclysm/main.cpp
@@ -5,13 +5,12 @@
 // Program entry point.
 //------------------------------------------------------------------------
 
-//#include "ExampleGame.h"
 #include <cstdlib>
+
+#include "KartGame.h"
 
 int main(int argc, char* argv[])
 {
-	//assignment1::ExampleGame exampleGame;
-	//return exampleGame.Run();
-	system("pause");
-	return 0;
+	Kartaclysm::KartGame *game = new Kartaclysm::KartGame();
+	return game->Run();
 }


### PR DESCRIPTION
Changed the base implementation of the State Machine and State classes to be stack-based. There is the option of having this extra utility be derived from the original version of the classes (parent and child), but for now I changed all State Machines to be stack-based. Easy fix if you don't like it.

In terms of the gameplay and menu states (as examples), the Suspend() and Unsuspend() methods can be used to toggle rendering as needed, while the owner can iterate through the stack using the StackBegin() and StackEnd() iterators to call Render() or other such methods on the states. PopToTopAndPush() will be helpful to pop up through the selection screens to the main menu and push the race onto the stack.

Remember that your state no longer exists after one Pop() command, meaning no more code can be called except to return. Hence why methods like PopAllAndPush() exist instead of the user manually calling Pop() multiple times. PopAll() by itself does not make sense and I don't see a reason for its existence, but hey I could be wrong.

Also, I removed GoToState() as its functionality is replaced by PopAndPush().
