### PR TITLE
Pause

### DIFF
--- a/CS483/CS483/CS483.vcxproj
+++ b/CS483/CS483/CS483.vcxproj
@@ -120,6 +120,7 @@
     <ClCompile Include="Kartaclysm\main.cpp" />
     <ClCompile Include="Kartaclysm\Services\IO\InputActionMapping.cpp" />
     <ClCompile Include="Kartaclysm\Services\IO\PlayerInputMapping.cpp" />
+    <ClCompile Include="Kartaclysm\StateMachine\Gameplay\StatePaused.cpp" />
     <ClCompile Include="Kartaclysm\StateMachine\Gameplay\StateRacing.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -193,6 +194,7 @@
     <ClInclude Include="Kartaclysm\Services\IO\InputActions.h" />
     <ClInclude Include="Kartaclysm\Services\IO\PlayerInputMapping.h" />
     <ClInclude Include="Kartaclysm\StateMachine\Gameplay\GameplayState.h" />
+    <ClInclude Include="Kartaclysm\StateMachine\Gameplay\StatePaused.h" />
     <ClInclude Include="Kartaclysm\StateMachine\Gameplay\StateRacing.h" />
     <Xml Include="Kartaclysm\Data\UserConfig\ControlBindings.xml" />
   </ItemGroup>

--- a/CS483/CS483/CS483.vcxproj.filters
+++ b/CS483/CS483/CS483.vcxproj.filters
@@ -243,6 +243,9 @@
     <ClCompile Include="..\..\HeatStroke\Common\Common.cpp">
       <Filter>HeatStroke\Common</Filter>
     </ClCompile>
+    <ClCompile Include="Kartaclysm\StateMachine\Gameplay\StatePaused.cpp">
+      <Filter>Kartaclysm\StateMachine\Gameplay</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\HeatStroke\Services\IO\KeyboardInputBuffer.h">
@@ -430,6 +433,9 @@
     </ClInclude>
     <ClInclude Include="..\..\HeatStroke\Common\Types.h">
       <Filter>HeatStroke\Common</Filter>
+    </ClInclude>
+    <ClInclude Include="Kartaclysm\StateMachine\Gameplay\StatePaused.h">
+      <Filter>Kartaclysm\StateMachine\Gameplay</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/CS483/CS483/Kartaclysm/Data/UserConfig/ControlBindings.xml
+++ b/CS483/CS483/Kartaclysm/Data/UserConfig/ControlBindings.xml
@@ -9,7 +9,7 @@
       <driverAbility2 value="83" />
       <kartAbility1 value="68" />
       <kartAbility2 value="70" />
-      <pause value="256" />
+      <pause value="257" />
   </Keyboard>
 
   <Joystick>

--- a/CS483/CS483/Kartaclysm/KartGame.cpp
+++ b/CS483/CS483/Kartaclysm/KartGame.cpp
@@ -27,6 +27,7 @@ bool Kartaclysm::KartGame::Init()
 	m_pGameStates = new HeatStroke::StateMachine();
 	m_pGameStates->SetStateMachineOwner(this);
 	m_pGameStates->RegisterState(0, new StateRacing());
+	m_pGameStates->RegisterState(1, new StatePaused());
 	m_pGameStates->Push(0);
 
 	return true;

--- a/CS483/CS483/Kartaclysm/KartGame.h
+++ b/CS483/CS483/Kartaclysm/KartGame.h
@@ -17,6 +17,7 @@
 #include "StateMachine.h"
 #include "GameplayState.h"
 #include "StateRacing.h"
+#include "StatePaused.h"
 #include "SceneManager.h"
 
 namespace Kartaclysm

--- a/CS483/CS483/Kartaclysm/Services/IO/InputActionMapping.cpp
+++ b/CS483/CS483/Kartaclysm/Services/IO/InputActionMapping.cpp
@@ -110,7 +110,7 @@ namespace Kartaclysm
 		}
 
 		// Helpful variables to avoid repetition
-		std::string strPlayerIdentifier = "P" + std::to_string(p_iPlayer) + "_";
+		std::string strPlayerIdentifier = "Player" + std::to_string(p_iPlayer);
 		HeatStroke::EventManager* pEventManager = HeatStroke::EventManager::Instance();
 
 		if (p_iGLFWJoystick == GLFW_JOYSTICK_LAST + 1) // Keyboard
@@ -120,23 +120,23 @@ namespace Kartaclysm
 			ActionMap mActionMap = (*m_pInputMap)[Input::eKeyboard];
 
 			// Iterate ability and pause actions
-			if (pBuffer->IsKeyDown(mActionMap[Racer::eDriverAbility1]))
+			if (pBuffer->IsKeyDownOnce(mActionMap[Racer::eDriverAbility1]))
 			{
-				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "Driver1"));
+				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "_DriverAbility1"));
 			}
-			if (pBuffer->IsKeyDown(mActionMap[Racer::eDriverAbility2]))
+			if (pBuffer->IsKeyDownOnce(mActionMap[Racer::eDriverAbility2]))
 			{
-				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "Driver2"));
+				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "_DriverAbility2"));
 			}
-			if (pBuffer->IsKeyDown(mActionMap[Racer::eKartAbility1]))
+			if (pBuffer->IsKeyDownOnce(mActionMap[Racer::eKartAbility1]))
 			{
-				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "Kart1"));
+				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "_KartAbility1"));
 			}
-			if (pBuffer->IsKeyDown(mActionMap[Racer::eKartAbility2]))
+			if (pBuffer->IsKeyDownOnce(mActionMap[Racer::eKartAbility2]))
 			{
-				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "Kart2"));
+				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "_KartAbility2"));
 			}
-			if (pBuffer->IsKeyDown(mActionMap[Racer::ePause]))
+			if (pBuffer->IsKeyDownOnce(mActionMap[Racer::ePause]))
 			{
 				HeatStroke::Event* pEvent = new HeatStroke::Event("Pause");
 				pEvent->SetIntParameter("Player", p_iPlayer);
@@ -150,23 +150,23 @@ namespace Kartaclysm
 			ActionMap mActionMap = (*m_pInputMap)[Input::eJoystick];
 
 			// Iterate ability and pause actions
-			if (pBuffer->IsButtonDown(p_iGLFWJoystick, mActionMap[Racer::eDriverAbility1]))
+			if (pBuffer->IsButtonDownOnce(p_iGLFWJoystick, mActionMap[Racer::eDriverAbility1]))
 			{
-				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "Driver1"));
+				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "_DriverAbility1"));
 			}
-			if (pBuffer->IsButtonDown(p_iGLFWJoystick, mActionMap[Racer::eDriverAbility2]))
+			if (pBuffer->IsButtonDownOnce(p_iGLFWJoystick, mActionMap[Racer::eDriverAbility2]))
 			{
-				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "Driver2"));
+				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "_DriverAbility2"));
 			}
-			if (pBuffer->IsButtonDown(p_iGLFWJoystick, mActionMap[Racer::eKartAbility1]))
+			if (pBuffer->IsButtonDownOnce(p_iGLFWJoystick, mActionMap[Racer::eKartAbility1]))
 			{
-				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "Kart1"));
+				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "_KartAbility1"));
 			}
-			if (pBuffer->IsButtonDown(p_iGLFWJoystick, mActionMap[Racer::eKartAbility2]))
+			if (pBuffer->IsButtonDownOnce(p_iGLFWJoystick, mActionMap[Racer::eKartAbility2]))
 			{
-				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "Kart2"));
+				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "_KartAbility2"));
 			}
-			if (pBuffer->IsButtonDown(p_iGLFWJoystick, mActionMap[Racer::ePause]))
+			if (pBuffer->IsButtonDownOnce(p_iGLFWJoystick, mActionMap[Racer::ePause]))
 			{
 				HeatStroke::Event* pEvent = new HeatStroke::Event("Pause");
 				pEvent->SetIntParameter("Player", p_iPlayer);
@@ -186,19 +186,19 @@ namespace Kartaclysm
 	{
 		if (p_iGLFWJoystick == GLFW_JOYSTICK_LAST + 1)
 		{
-			return HeatStroke::KeyboardInputBuffer::Instance()->IsKeyDown((*m_pInputMap)[Input::eKeyboard][p_eAction]);
+			return HeatStroke::KeyboardInputBuffer::Instance()->IsKeyDownContinuous((*m_pInputMap)[Input::eKeyboard][p_eAction]);
 		}
 		else
 		{
 			if (p_eAction == Racer::eSlide)
 			{
 				// Sliding is controlled by button or by the bumpers
-				bool bSlide = HeatStroke::JoystickInputBuffer::Instance()->IsButtonDown(p_iGLFWJoystick, (*m_pInputMap)[Input::eJoystick][Racer::eSlide]);
+				bool bSlide = HeatStroke::JoystickInputBuffer::Instance()->IsButtonDownContinuous(p_iGLFWJoystick, (*m_pInputMap)[Input::eJoystick][Racer::eSlide]);
 				return (bSlide == true ? true : static_cast<float>(HeatStroke::JoystickInputBuffer::Instance()->GetAxis(p_iGLFWJoystick, XBOX_AXIS_TRIGGERS)) != 0.0f);
 			}
 			else
 			{
-				return HeatStroke::JoystickInputBuffer::Instance()->IsButtonDown(p_iGLFWJoystick, (*m_pInputMap)[Input::eJoystick][p_eAction]);
+				return HeatStroke::JoystickInputBuffer::Instance()->IsButtonDownContinuous(p_iGLFWJoystick, (*m_pInputMap)[Input::eJoystick][p_eAction]);
 			}
 		}
 	}
@@ -214,16 +214,16 @@ namespace Kartaclysm
 		float fTurn = 0.0f;
 		if (p_iGLFWJoystick == GLFW_JOYSTICK_LAST + 1)
 		{
-			fTurn = static_cast<float>(HeatStroke::KeyboardInputBuffer::Instance()->IsKeyDown((*m_pInputMap)[Input::eKeyboard][Racer::eRight]));
-			fTurn -= static_cast<float>(HeatStroke::KeyboardInputBuffer::Instance()->IsKeyDown((*m_pInputMap)[Input::eKeyboard][Racer::eLeft]));
+			fTurn = static_cast<float>(HeatStroke::KeyboardInputBuffer::Instance()->IsKeyDownContinuous((*m_pInputMap)[Input::eKeyboard][Racer::eRight]));
+			fTurn -= static_cast<float>(HeatStroke::KeyboardInputBuffer::Instance()->IsKeyDownContinuous((*m_pInputMap)[Input::eKeyboard][Racer::eLeft]));
 		}
 		else
 		{
 			fTurn = HeatStroke::JoystickInputBuffer::Instance()->GetAxis(p_iGLFWJoystick, (*m_pInputMap)[Input::eJoystick][Racer::eAnalogStick]);
 			if (fTurn == 0.0f)
 			{
-				fTurn = static_cast<float>(HeatStroke::JoystickInputBuffer::Instance()->IsButtonDown(p_iGLFWJoystick, (*m_pInputMap)[Input::eJoystick][Racer::eRight]));
-				fTurn -= static_cast<float>(HeatStroke::JoystickInputBuffer::Instance()->IsButtonDown(p_iGLFWJoystick, (*m_pInputMap)[Input::eJoystick][Racer::eLeft]));
+				fTurn = static_cast<float>(HeatStroke::JoystickInputBuffer::Instance()->IsButtonDownContinuous(p_iGLFWJoystick, (*m_pInputMap)[Input::eJoystick][Racer::eRight]));
+				fTurn -= static_cast<float>(HeatStroke::JoystickInputBuffer::Instance()->IsButtonDownContinuous(p_iGLFWJoystick, (*m_pInputMap)[Input::eJoystick][Racer::eLeft]));
 			}
 		}
 		return fTurn;
@@ -249,7 +249,7 @@ namespace Kartaclysm
 			(*m_pInputMap)[Input::eKeyboard][Racer::eDriverAbility2] =	GLFW_KEY_S;
 			(*m_pInputMap)[Input::eKeyboard][Racer::eKartAbility1] =	GLFW_KEY_D;
 			(*m_pInputMap)[Input::eKeyboard][Racer::eKartAbility2] =	GLFW_KEY_F;
-			(*m_pInputMap)[Input::eKeyboard][Racer::ePause] =			GLFW_KEY_ESCAPE;
+			(*m_pInputMap)[Input::eKeyboard][Racer::ePause] =			GLFW_KEY_ENTER;
 		}
 
 		if (p_bResetJoystick)

--- a/CS483/CS483/Kartaclysm/Services/IO/InputActionMapping.cpp
+++ b/CS483/CS483/Kartaclysm/Services/IO/InputActionMapping.cpp
@@ -109,59 +109,70 @@ namespace Kartaclysm
 			return;
 		}
 
-		HeatStroke::Event* pEvent = new HeatStroke::Event("PlayerInput_" + p_iPlayer);
+		// Helpful variables to avoid repetition
+		std::string strPlayerIdentifier = "P" + std::to_string(p_iPlayer) + "_";
+		HeatStroke::EventManager* pEventManager = HeatStroke::EventManager::Instance();
 
-		if (p_iGLFWJoystick == GLFW_JOYSTICK_LAST + 1)
+		if (p_iGLFWJoystick == GLFW_JOYSTICK_LAST + 1) // Keyboard
 		{
-			// Keyboard keys
+			// Helpful variables to avoid repetition
 			HeatStroke::KeyboardInputBuffer* pBuffer = HeatStroke::KeyboardInputBuffer::Instance();
-			pEvent->SetIntParameter("Accelerate", static_cast<int>(pBuffer->IsKeyDown((*m_pInputMap)[Input::eKeyboard][Racer::eAccelerate])));
-			pEvent->SetIntParameter("Brake", static_cast<int>(pBuffer->IsKeyDown((*m_pInputMap)[Input::eKeyboard][Racer::eBrake])));
-			pEvent->SetIntParameter("Slide", static_cast<int>(pBuffer->IsKeyDown((*m_pInputMap)[Input::eKeyboard][Racer::eSlide])));
-			pEvent->SetIntParameter("Driver1", static_cast<int>(pBuffer->IsKeyDown((*m_pInputMap)[Input::eKeyboard][Racer::eDriverAbility1])));
-			pEvent->SetIntParameter("Driver2", static_cast<int>(pBuffer->IsKeyDown((*m_pInputMap)[Input::eKeyboard][Racer::eDriverAbility2])));
-			pEvent->SetIntParameter("Kart1", static_cast<int>(pBuffer->IsKeyDown((*m_pInputMap)[Input::eKeyboard][Racer::eKartAbility1])));
-			pEvent->SetIntParameter("Kart2", static_cast<int>(pBuffer->IsKeyDown((*m_pInputMap)[Input::eKeyboard][Racer::eKartAbility2])));
-			pEvent->SetIntParameter("Pause", static_cast<int>(pBuffer->IsKeyDown((*m_pInputMap)[Input::eKeyboard][Racer::ePause])));
+			ActionMap mActionMap = (*m_pInputMap)[Input::eKeyboard];
 
-			// For compatibility with joysticks, turn is a float value: Right adds +1.0f, Left adds -1.0f
-			float fTurn = static_cast<float>(pBuffer->IsKeyDown((*m_pInputMap)[Input::eKeyboard][Racer::eRight]));
-			fTurn -= static_cast<float>(pBuffer->IsKeyDown((*m_pInputMap)[Input::eKeyboard][Racer::eLeft]));
-			pEvent->SetFloatParameter("Turn", fTurn);
+			// Iterate ability and pause actions
+			if (pBuffer->IsKeyDown(mActionMap[Racer::eDriverAbility1]))
+			{
+				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "Driver1"));
+			}
+			if (pBuffer->IsKeyDown(mActionMap[Racer::eDriverAbility2]))
+			{
+				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "Driver2"));
+			}
+			if (pBuffer->IsKeyDown(mActionMap[Racer::eKartAbility1]))
+			{
+				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "Kart1"));
+			}
+			if (pBuffer->IsKeyDown(mActionMap[Racer::eKartAbility2]))
+			{
+				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "Kart2"));
+			}
+			if (pBuffer->IsKeyDown(mActionMap[Racer::ePause]))
+			{
+				HeatStroke::Event* pEvent = new HeatStroke::Event("Pause");
+				pEvent->SetIntParameter("Player", p_iPlayer);
+				pEventManager->TriggerEvent(pEvent);
+			}
 		}
-		else
+		else // Not keyboard (joystick)
 		{
-			// Joystick buttons
+			// Helpful variables to avoid repetition
 			HeatStroke::JoystickInputBuffer* pBuffer = HeatStroke::JoystickInputBuffer::Instance();
-			pEvent->SetIntParameter("Accelerate", static_cast<int>(pBuffer->IsButtonDown(p_iGLFWJoystick, (*m_pInputMap)[Input::eJoystick][Racer::eAccelerate])));
-			pEvent->SetIntParameter("Brake", static_cast<int>(pBuffer->IsButtonDown(p_iGLFWJoystick, (*m_pInputMap)[Input::eJoystick][Racer::eBrake])));
-			pEvent->SetIntParameter("Driver1", static_cast<int>(pBuffer->IsButtonDown(p_iGLFWJoystick, (*m_pInputMap)[Input::eJoystick][Racer::eDriverAbility1])));
-			pEvent->SetIntParameter("Driver2", static_cast<int>(pBuffer->IsButtonDown(p_iGLFWJoystick, (*m_pInputMap)[Input::eJoystick][Racer::eDriverAbility2])));
-			pEvent->SetIntParameter("Kart1", static_cast<int>(pBuffer->IsButtonDown(p_iGLFWJoystick, (*m_pInputMap)[Input::eJoystick][Racer::eKartAbility1])));
-			pEvent->SetIntParameter("Kart2", static_cast<int>(pBuffer->IsButtonDown(p_iGLFWJoystick, (*m_pInputMap)[Input::eJoystick][Racer::eKartAbility2])));
-			pEvent->SetIntParameter("Pause", static_cast<int>(pBuffer->IsButtonDown(p_iGLFWJoystick, (*m_pInputMap)[Input::eJoystick][Racer::ePause])));
+			ActionMap mActionMap = (*m_pInputMap)[Input::eJoystick];
 
-			// Sliding may be controlled by button OR by RT/LT axis
-			int iSlide = static_cast<int>(pBuffer->IsButtonDown(p_iGLFWJoystick, (*m_pInputMap)[Input::eJoystick][Racer::eSlide]));
-			if (iSlide == 0)
+			// Iterate ability and pause actions
+			if (pBuffer->IsButtonDown(p_iGLFWJoystick, mActionMap[Racer::eDriverAbility1]))
 			{
-				float fSlide = pBuffer->GetAxis(p_iGLFWJoystick, XBOX_AXIS_TRIGGERS);
-				iSlide = (fSlide == 0.0f ? 0 : 1);
+				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "Driver1"));
 			}
-			pEvent->SetIntParameter("Slide", iSlide);
-
-			// Analog stick takes priority over d-pad for turning
-			float fTurn = pBuffer->GetAxis(p_iGLFWJoystick, (*m_pInputMap)[Input::eJoystick][Racer::eAnalogStick]);
-			if (fTurn == 0.0f)
+			if (pBuffer->IsButtonDown(p_iGLFWJoystick, mActionMap[Racer::eDriverAbility2]))
 			{
-				fTurn = static_cast<float>(pBuffer->IsButtonDown(p_iGLFWJoystick, (*m_pInputMap)[Input::eJoystick][Racer::eRight]));
-				fTurn -= static_cast<float>(pBuffer->IsButtonDown(p_iGLFWJoystick, (*m_pInputMap)[Input::eJoystick][Racer::eLeft]));
+				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "Driver2"));
 			}
-			pEvent->SetFloatParameter("Turn", fTurn);
-
+			if (pBuffer->IsButtonDown(p_iGLFWJoystick, mActionMap[Racer::eKartAbility1]))
+			{
+				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "Kart1"));
+			}
+			if (pBuffer->IsButtonDown(p_iGLFWJoystick, mActionMap[Racer::eKartAbility2]))
+			{
+				pEventManager->TriggerEvent(new HeatStroke::Event(strPlayerIdentifier + "Kart2"));
+			}
+			if (pBuffer->IsButtonDown(p_iGLFWJoystick, mActionMap[Racer::ePause]))
+			{
+				HeatStroke::Event* pEvent = new HeatStroke::Event("Pause");
+				pEvent->SetIntParameter("Player", p_iPlayer);
+				pEventManager->TriggerEvent(pEvent);
+			}
 		}
-
-		HeatStroke::EventManager::Instance()->TriggerEvent(pEvent);
 	}
 
 	//--------------------------------------------------------------------------------

--- a/CS483/CS483/Kartaclysm/Services/IO/InputActionMapping.cpp
+++ b/CS483/CS483/Kartaclysm/Services/IO/InputActionMapping.cpp
@@ -249,7 +249,7 @@ namespace Kartaclysm
 			(*m_pInputMap)[Input::eKeyboard][Racer::eDriverAbility2] =	GLFW_KEY_S;
 			(*m_pInputMap)[Input::eKeyboard][Racer::eKartAbility1] =	GLFW_KEY_D;
 			(*m_pInputMap)[Input::eKeyboard][Racer::eKartAbility2] =	GLFW_KEY_F;
-			(*m_pInputMap)[Input::eKeyboard][Racer::ePause] =			GLFW_KEY_ESCAPE;
+			(*m_pInputMap)[Input::eKeyboard][Racer::ePause] =			GLFW_KEY_ENTER;
 		}
 
 		if (p_bResetJoystick)

--- a/CS483/CS483/Kartaclysm/Services/IO/InputActionMapping.h
+++ b/CS483/CS483/Kartaclysm/Services/IO/InputActionMapping.h
@@ -61,7 +61,10 @@ namespace Kartaclysm
 		// Private methods
 		//-------------------------------------------------------------
 
+		// Called every frame by PlayerInputMapping::Update
 		void SendInputEventForPlayer(const int p_iPlayer, const int p_iGLFWJoystick);
+
+		// Manual query for inputs by PlayerInputMapping::QueryPlayerInput
 		bool GetButton(const int p_iGLFWJoystick, const Racer::Action p_eAction);
 		float GetTurning(const int p_iGLFWJoystick);
 

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/GameplayState.h
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/GameplayState.h
@@ -10,6 +10,7 @@
 
 #include "State.h"
 #include "GameObjectManager.h"
+#include "StateMachine.h"
 
 namespace Kartaclysm
 {

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StatePaused.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StatePaused.cpp
@@ -1,0 +1,153 @@
+//------------------------------------------------------------------------
+// StatePaused
+// Author:	Bradley Cooper
+//	
+// Gameplay state for racing.
+//------------------------------------------------------------------------
+
+#include "StatePaused.h"
+
+#include "ComponentCamera.h"
+
+//------------------------------------------------------------------------------
+// Method:    StatePaused
+// Returns:   
+// 
+// Constructor.
+//------------------------------------------------------------------------------
+Kartaclysm::StatePaused::StatePaused()
+	:
+	m_pGameObjectManager(nullptr),
+	m_bSuspended(true),
+	m_iPausedPlayer(-1),
+	m_pPauseDelegate(nullptr)
+{
+}
+
+//------------------------------------------------------------------------------
+// Method:    ~StatePaused
+// Returns:   
+// 
+// Destructor.
+//------------------------------------------------------------------------------
+Kartaclysm::StatePaused::~StatePaused()
+{
+	Exit();
+}
+
+//------------------------------------------------------------------------------
+// Method:		Enter
+// Parameter:	std::map<std::string, std::string> p_mContextParameters - parameters for state
+// 
+// Called when this state is pushed onto the stack.
+//------------------------------------------------------------------------------
+void Kartaclysm::StatePaused::Enter(const std::map<std::string, std::string>& p_mContextParameters)
+{
+	m_bSuspended = false;
+
+	// Register listening for pause
+	m_pPauseDelegate = new std::function<void(const HeatStroke::Event*)>(std::bind(&StatePaused::PauseGame, this, std::placeholders::_1));
+	HeatStroke::EventManager::Instance()->AddListener("Pause", m_pPauseDelegate);
+
+	// Initialize our GameObjectManager
+	m_pGameObjectManager = new HeatStroke::GameObjectManager();
+
+	// Register component factory methods
+
+	// Handle passed context parameters
+	auto it = p_mContextParameters.find("Player");
+	if (it != p_mContextParameters.end())
+	{
+		m_iPausedPlayer = atoi(it->second.c_str());
+	}
+
+	// Load the GameObjects from XML.
+}
+
+//------------------------------------------------------------------------------
+// Method:		Suspend
+// Parameter:	const int p_iNewState - index of new state being pushed
+// 
+// Called when this state is pushed down in the stack.
+//------------------------------------------------------------------------------
+void Kartaclysm::StatePaused::Suspend(const int p_iNewState)
+{
+	m_bSuspended = true;
+}
+
+//------------------------------------------------------------------------------
+// Method:		Unsuspend
+// Parameter:	const int p_iPrevState - index of previous state popped
+// 
+// Called when this state is popped back to top of stack.
+//------------------------------------------------------------------------------
+void Kartaclysm::StatePaused::Unsuspend(const int p_iPrevState)
+{
+	m_bSuspended = false;
+}
+
+//------------------------------------------------------------------------------
+// Method:    Update
+// Parameter: const float p_fDelta
+// 
+// Called each from when this state is active.
+//------------------------------------------------------------------------------
+void Kartaclysm::StatePaused::Update(const float p_fDelta)
+{
+	// Do not update when suspended
+	if (!m_bSuspended)
+	{
+		m_pGameObjectManager->Update(p_fDelta);
+	}
+}
+
+//------------------------------------------------------------------------------
+// Method:    PreRender
+// 
+// Called before rendering occurs.
+//------------------------------------------------------------------------------
+void Kartaclysm::StatePaused::PreRender()
+{
+	// Render even when suspended
+	m_pGameObjectManager->PreRender();
+}
+
+//------------------------------------------------------------------------------
+// Method:    Exit
+// 
+// Called when this state is popped off the stack.
+//------------------------------------------------------------------------------
+void Kartaclysm::StatePaused::Exit()
+{
+	m_bSuspended = false;
+
+	if (m_pPauseDelegate != nullptr)
+	{
+		HeatStroke::EventManager::Instance()->RemoveListener("Pause", m_pPauseDelegate);
+		delete m_pPauseDelegate;
+		m_pPauseDelegate = nullptr;
+	}
+
+	if (m_pGameObjectManager != nullptr)
+	{
+		m_pGameObjectManager->DestroyAllGameObjects();
+		delete m_pGameObjectManager;
+		m_pGameObjectManager = nullptr;
+	}
+}
+
+//------------------------------------------------------------------------------
+// Method:    PauseGame
+// Parameter: const HeatStroke::Event* p_pEvent - Event that triggers when a player pauses
+// 
+// Unpause the game by popping the Pause State.
+//------------------------------------------------------------------------------
+void Kartaclysm::StatePaused::PauseGame(const HeatStroke::Event* p_pEvent)
+{
+	// Get the player who paused the game
+	int iPlayer = 0;
+	p_pEvent->GetOptionalIntParameter("Player", iPlayer, iPlayer);
+
+	// Pop current state
+	m_pStateMachine->Pop();
+}

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StatePaused.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StatePaused.cpp
@@ -161,6 +161,5 @@ void Kartaclysm::StatePaused::PauseGame(const HeatStroke::Event* p_pEvent)
 	p_pEvent->GetOptionalIntParameter("Player", iPlayer, iPlayer);
 
 	// Pop current state
-	printf("Unpausing\n");
 	m_pStateMachine->Pop();
 }

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StatePaused.h
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StatePaused.h
@@ -1,34 +1,28 @@
 //------------------------------------------------------------------------
-// StateRacing
+// StatePaused
 // Author:	Bradley Cooper
 //	
-// Gameplay state for racing.
+// Gameplay state for pausing during a race.
 //------------------------------------------------------------------------
 
-#ifndef STATE_RACING_H
-#define STATE_RACING_H
+#ifndef STATE_PAUSED_H
+#define STATE_PAUSED_H
 
 #include <functional>
 
-#include "Common.h"
 #include "GameplayState.h"
-#include "Component3DModel.h"
-#include "ComponentAmbientLight.h"
-#include "ComponentDirectionalLight.h"
 #include "EventManager.h"
-
-#include "LineDrawer.h"
 
 namespace Kartaclysm
 {
-	class StateRacing : public Kartaclysm::GameplayState
+	class StatePaused : public Kartaclysm::GameplayState
 	{
 	public:
 		//------------------------------------------------------------------------------
 		// Public methods.
 		//------------------------------------------------------------------------------
-		StateRacing();
-		virtual ~StateRacing();
+		StatePaused();
+		virtual ~StatePaused();
 
 		// Inherited
 		void Enter(const std::map<std::string, std::string>& p_mContextParameters);
@@ -39,17 +33,14 @@ namespace Kartaclysm
 		void Exit();
 
 	protected:
-
-		HeatStroke::LineDrawer *lineDrawer;
-
 		// Inherited
 		HeatStroke::GameObjectManager* m_pGameObjectManager;
 		bool m_bSuspended;
 
 	private:
+		int m_iPausedPlayer;
 		std::function<void(const HeatStroke::Event*)>* m_pPauseDelegate;
 
-		void LoadLevel(const std::string& p_strLevelPath);
 		void PauseGame(const HeatStroke::Event* p_pEvent);
 	};
 } // namespace Kartaclysm

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRacing.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRacing.cpp
@@ -102,6 +102,13 @@ void Kartaclysm::StateRacing::LoadLevel(const std::string& p_strLevelPath)
 void Kartaclysm::StateRacing::Suspend(const int p_iNewState)
 {
 	m_bSuspended = true;
+
+	if (m_pPauseDelegate != nullptr)
+	{
+		HeatStroke::EventManager::Instance()->RemoveListener("Pause", m_pPauseDelegate);
+		delete m_pPauseDelegate;
+		m_pPauseDelegate = nullptr;
+	}
 }
 
 //------------------------------------------------------------------------------
@@ -113,6 +120,12 @@ void Kartaclysm::StateRacing::Suspend(const int p_iNewState)
 void Kartaclysm::StateRacing::Unsuspend(const int p_iPrevState)
 {
 	m_bSuspended = false;
+
+	if (m_pPauseDelegate == nullptr)
+	{
+		m_pPauseDelegate = new std::function<void(const HeatStroke::Event*)>(std::bind(&StateRacing::PauseGame, this, std::placeholders::_1));
+		HeatStroke::EventManager::Instance()->AddListener("Pause", m_pPauseDelegate);
+	}
 }
 
 //------------------------------------------------------------------------------
@@ -210,5 +223,6 @@ void Kartaclysm::StateRacing::PauseGame(const HeatStroke::Event* p_pEvent)
 	mContext["Player"] = std::to_string(iPlayer);
 
 	// Push pause state
+	printf("Pausing\n");
 	m_pStateMachine->Push(1, mContext);
 }

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRacing.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRacing.cpp
@@ -20,7 +20,8 @@
 Kartaclysm::StateRacing::StateRacing()
 	:
 	m_pGameObjectManager(nullptr),
-	m_bSuspended(true)
+	m_bSuspended(true),
+	m_pPauseDelegate(nullptr)
 {
 }
 
@@ -44,6 +45,10 @@ Kartaclysm::StateRacing::~StateRacing()
 void Kartaclysm::StateRacing::Enter(const std::map<std::string, std::string>& p_mContextParameters)
 {
 	m_bSuspended = false;
+
+	// Register listening for pause
+	m_pPauseDelegate = new std::function<void(const HeatStroke::Event*)>(std::bind(&StateRacing::PauseGame, this, std::placeholders::_1));
+	HeatStroke::EventManager::Instance()->AddListener("Pause", m_pPauseDelegate);
 
 	// Initialize our GameObjectManager
 	m_pGameObjectManager = new HeatStroke::GameObjectManager();
@@ -173,10 +178,37 @@ void Kartaclysm::StateRacing::Exit()
 {
 	m_bSuspended = false;
 
+	if (m_pPauseDelegate != nullptr)
+	{
+		HeatStroke::EventManager::Instance()->RemoveListener("Pause", m_pPauseDelegate);
+		delete m_pPauseDelegate;
+		m_pPauseDelegate = nullptr;
+	}
+
 	if (m_pGameObjectManager != nullptr)
 	{
 		m_pGameObjectManager->DestroyAllGameObjects();
 		delete m_pGameObjectManager;
 		m_pGameObjectManager = nullptr;
 	}
+}
+
+//------------------------------------------------------------------------------
+// Method:    PauseGame
+// Parameter: const HeatStroke::Event* p_pEvent - Event that triggers when a player pauses
+// 
+// Pause the game by pushing the Pause State.
+//------------------------------------------------------------------------------
+void Kartaclysm::StateRacing::PauseGame(const HeatStroke::Event* p_pEvent)
+{
+	// Get the player who paused the game
+	int iPlayer = 0;
+	p_pEvent->GetOptionalIntParameter("Player", iPlayer, iPlayer);
+
+	// Create context for pushing to pause state
+	HeatStroke::StateMachine::ContextParameters mContext = HeatStroke::StateMachine::ContextParameters();
+	mContext["Player"] = std::to_string(iPlayer);
+
+	// Push pause state
+	m_pStateMachine->Push(1, mContext);
 }

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRacing.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRacing.cpp
@@ -223,6 +223,5 @@ void Kartaclysm::StateRacing::PauseGame(const HeatStroke::Event* p_pEvent)
 	mContext["Player"] = std::to_string(iPlayer);
 
 	// Push pause state
-	printf("Pausing\n");
 	m_pStateMachine->Push(1, mContext);
 }

--- a/HeatStroke/Services/Events/EventManager.cpp
+++ b/HeatStroke/Services/Events/EventManager.cpp
@@ -137,8 +137,11 @@ namespace HeatStroke
 		{
 			// Iterate over the listeners and call their handler method with
 			// the Event parameter.
-			ListenerList::iterator it = findListenerList->second.begin();
-			ListenerList::iterator end = findListenerList->second.end();
+			// TO DO, currently uses local copy to avoid iterator problems if
+			// AddListener() or RemoveListener() are called during event dispatch
+			ListenerList mLocalCopy(findListenerList->second);
+			ListenerList::iterator it = mLocalCopy.begin();
+			ListenerList::iterator end = mLocalCopy.end();
 
 			for (; it != end; ++it)
 			{

--- a/HeatStroke/Services/IO/JoystickInputBuffer.h
+++ b/HeatStroke/Services/IO/JoystickInputBuffer.h
@@ -53,9 +53,11 @@ namespace HeatStroke
 		// Game Loop Method
 		void Update(const float p_fDelta);
 
-		// Returns true if the given button is down. False if not, or
-		// if the key is not supported.
-		bool IsButtonDown(const int p_iGLFWJoystick, const char p_iGLFWJoystickButton) const;
+		// Returns true if the given button is down this frame but was not last frame.
+		bool IsButtonDownOnce(const int p_iGLFWJoystick, const char p_iGLFWKeyConstant) const;
+
+		// Returns true if the given button is down.
+		bool IsButtonDownContinuous(const int p_iGLFWJoystick, const char p_iGLFWJoystickButton) const;
 
 		// Sets parameters to axes tilt if they exceed the dead zone,
 		// otherwise set to 0. Positive indicates right and up.
@@ -87,7 +89,7 @@ namespace HeatStroke
 		void Init();
 
 		// Helper function
-		Joystick* const GetJoystick(const int p_iGLFWJoystick) const;
+		Joystick* const GetJoystick(const int p_iGLFWJoystick, const bool p_bPreviousFrame = false) const;
 	};
 }
 

--- a/HeatStroke/Services/IO/KeyboardInputBuffer.cpp
+++ b/HeatStroke/Services/IO/KeyboardInputBuffer.cpp
@@ -254,13 +254,33 @@ namespace HeatStroke
 	}
 
 	//--------------------------------------------------------------------------------
-	// KeyboardInputBuffer::IsKeyDown
+	// KeyboardInputBuffer::IsKeyDownOnce
+	// Parameter: const int p_iGLFWKeyConstant - the key to check, should be a glfw key constant.
+	//
+	// Returns true if the given key is down this frame but was
+	// not last frame. False if not, or if the key is not supported.
+	//--------------------------------------------------------------------------------
+	bool KeyboardInputBuffer::IsKeyDownOnce(const int p_iGLFWKeyConstant) const
+	{
+		KeyMap::iterator findCurr = m_pKeysDown->find(p_iGLFWKeyConstant);
+		KeyMap::iterator findPrev = m_pKeysDownLast->find(p_iGLFWKeyConstant);
+		if (findCurr != m_pKeysDown->end() &&
+			findPrev != m_pKeysDownLast->end())
+		{
+			return (findCurr->second && !findPrev->second);
+		}
+
+		return false;
+	}
+
+	//--------------------------------------------------------------------------------
+	// KeyboardInputBuffer::IsKeyDownContinuous
 	// Parameter: const int p_iGLFWKeyConstant - the key to check, should be a glfw key constant.
 	//
 	// Returns true if the given key is down. False if not, or
 	// if the key is not supported.
 	//--------------------------------------------------------------------------------
-	bool KeyboardInputBuffer::IsKeyDown(const int p_iGLFWKeyConstant) const
+	bool KeyboardInputBuffer::IsKeyDownContinuous(const int p_iGLFWKeyConstant) const
 	{
 		KeyMap::iterator find = m_pKeysDown->find(p_iGLFWKeyConstant);
 		if (find != m_pKeysDown->end())

--- a/HeatStroke/Services/IO/KeyboardInputBuffer.h
+++ b/HeatStroke/Services/IO/KeyboardInputBuffer.h
@@ -34,9 +34,13 @@ namespace HeatStroke
 		// Returns true if the given key is tracked by GLFW.
 		bool IsValidKey(const int p_iGLFWKeyConstant) const;
 
+		// Returns true if the given key is down this frame but was
+		// not last frame. False if not, or if the key is not supported.
+		bool IsKeyDownOnce(const int p_iGLFWKeyConstant) const;
+
 		// Returns true if the given key is down. False if not, or
 		// if the key is not supported.
-		bool IsKeyDown(const int p_iGLFWKeyConstant) const;
+		bool IsKeyDownContinuous(const int p_iGLFWKeyConstant) const;
 
 	private:
 		//-------------------------------------------------------------


### PR DESCRIPTION
Merges additions to feature/input as well.

Hacky implementation that does its job. Two issues I am aware of:

1) Pressing the Pause button rapidly shifts from Pause/Unpause as the Input Buffers read if the key is pressed down every frame, not if it's pressed down once. Added this to the backlog and will tackle it later.

2) Had to create a local copy of Listeners in Event Manager. Whenever a State calls Exit/Suspend, it removes its Listener, and likewise adds it whenever it calls Enter/Unsuspend. Doing this calls changes the vector for the Listeners, which in turn cancels all iterators in use. Sadly, this all happens during the dispatch of the event that uses this iterator. Compiler error ahoy!

A local copy solves this problem, but could also be solved by QueueAddListener() and QueueRemoveListener() methods. I took the easier option. Delaying the removal at StateMachine-side doesn't work for the case when Exit() is called, as this cannot be delayed without also keeping that State in the StateMachine stack, which is not ideal.