### PR TITLE
Feature/test state

### DIFF
--- a/CS483/CS483/CS483.vcxproj
+++ b/CS483/CS483/CS483.vcxproj
@@ -148,6 +148,7 @@
     <ClCompile Include="Kartaclysm\Services\IO\PlayerInputMapping.cpp" />
     <ClCompile Include="Kartaclysm\StateMachine\Gameplay\StatePaused.cpp" />
     <ClCompile Include="Kartaclysm\StateMachine\Gameplay\StateRacing.cpp" />
+    <ClCompile Include="Kartaclysm\StateMachine\Gameplay\StateMainMenu.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\HeatStroke\Common\Common.h" />
@@ -235,6 +236,7 @@
     <ClInclude Include="Kartaclysm\Components\HUD\ComponentHudPosition.h" />
     <ClInclude Include="Kartaclysm\Components\HUD\ComponentHudRaceTimer.h" />
     <ClInclude Include="Kartaclysm\KartGame.h" />
+    <ClInclude Include="Kartaclysm\StateMachine\Gameplay\StateMainMenu.h" />
   </ItemGroup>
   <ItemGroup>
     <Xml Include="Kartaclysm\Data\Abilities\kart_showoff_wheelie.xml" />

--- a/CS483/CS483/CS483.vcxproj.filters
+++ b/CS483/CS483/CS483.vcxproj.filters
@@ -345,6 +345,9 @@
     <ClCompile Include="Kartaclysm\Components\ComponentSelfDestruct.cpp">
       <Filter>Kartaclysm\Components</Filter>
     </ClCompile>
+    <ClCompile Include="Kartaclysm\StateMachine\Gameplay\StateMainMenu.cpp">
+      <Filter>Kartaclysm\StateMachine\Gameplay</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\HeatStroke\Services\IO\KeyboardInputBuffer.h">
@@ -619,6 +622,9 @@
     </ClInclude>
     <ClInclude Include="Kartaclysm\Components\ComponentSelfDestruct.h">
       <Filter>Kartaclysm\Components</Filter>
+    </ClInclude>
+    <ClInclude Include="Kartaclysm\StateMachine\Gameplay\StateMainMenu.h">
+      <Filter>Kartaclysm\StateMachine\Gameplay</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/CS483/CS483/Kartaclysm/KartGame.cpp
+++ b/CS483/CS483/Kartaclysm/KartGame.cpp
@@ -43,7 +43,8 @@ bool Kartaclysm::KartGame::Init()
 	m_pGameStates->SetStateMachineOwner(this);
 	m_pGameStates->RegisterState(0, new StateRacing());
 	m_pGameStates->RegisterState(1, new StatePaused());
-	m_pGameStates->Push(0, mContextParams);
+	m_pGameStates->RegisterState(2, new StateMainMenu());
+	m_pGameStates->Push(2, mContextParams);
 
 	return true;
 }

--- a/CS483/CS483/Kartaclysm/KartGame.h
+++ b/CS483/CS483/Kartaclysm/KartGame.h
@@ -18,6 +18,7 @@
 #include "GameplayState.h"
 #include "StateRacing.h"
 #include "StatePaused.h"
+#include "StateMainMenu.h"
 #include "SceneManager.h"
 
 namespace Kartaclysm

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateMainMenu.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateMainMenu.cpp
@@ -1,0 +1,113 @@
+//------------------------------------------------------------------------
+// StateMainMenu
+// Author:	Bradley Cooper
+//	
+// Gameplay state first viewed when the game loads.
+//------------------------------------------------------------------------
+
+#include "StateMainMenu.h"
+
+//------------------------------------------------------------------------------
+// Method:    StateMainMenu
+// Returns:   
+// 
+// Constructor.
+//------------------------------------------------------------------------------
+Kartaclysm::StateMainMenu::StateMainMenu()
+	:
+	m_pGameObjectManager(nullptr),
+	m_bSuspended(true)
+{
+}
+
+//------------------------------------------------------------------------------
+// Method:    ~StateMainMenu
+// Returns:   
+// 
+// Destructor.
+//------------------------------------------------------------------------------
+Kartaclysm::StateMainMenu::~StateMainMenu()
+{
+	Exit();
+}
+
+//------------------------------------------------------------------------------
+// Method:		Enter
+// Parameter:	std::map<std::string, std::string> p_mContextParameters - parameters for state
+// 
+// Called when this state is pushed onto the stack.
+//------------------------------------------------------------------------------
+void Kartaclysm::StateMainMenu::Enter(const std::map<std::string, std::string>& p_mContextParameters)
+{
+	m_bSuspended = false;
+
+	m_pStateMachine->Pop();
+	m_pStateMachine->Push(0, p_mContextParameters);
+}
+
+//------------------------------------------------------------------------------
+// Method:		Suspend
+// Parameter:	const int p_iNewState - index of new state being pushed
+// 
+// Called when this state is pushed down in the stack.
+//------------------------------------------------------------------------------
+void Kartaclysm::StateMainMenu::Suspend(const int p_iNewState)
+{
+	m_bSuspended = true;
+}
+
+//------------------------------------------------------------------------------
+// Method:		Unsuspend
+// Parameter:	const int p_iPrevState - index of previous state popped
+// 
+// Called when this state is popped back to top of stack.
+//------------------------------------------------------------------------------
+void Kartaclysm::StateMainMenu::Unsuspend(const int p_iPrevState)
+{
+	m_bSuspended = false;
+}
+
+//------------------------------------------------------------------------------
+// Method:    Update
+// Parameter: const float p_fDelta
+// 
+// Called each from when this state is active.
+//------------------------------------------------------------------------------
+void Kartaclysm::StateMainMenu::Update(const float p_fDelta)
+{
+	// Do not update when suspended
+	if (!m_bSuspended)
+	{
+		assert(m_pGameObjectManager != nullptr);
+		m_pGameObjectManager->Update(p_fDelta);
+	}
+}
+
+//------------------------------------------------------------------------------
+// Method:    PreRender
+// 
+// Called before rendering occurs.
+//------------------------------------------------------------------------------
+void Kartaclysm::StateMainMenu::PreRender()
+{
+	// Render even when suspended
+	assert(m_pGameObjectManager != nullptr);
+	m_pGameObjectManager->PreRender();
+}
+
+//------------------------------------------------------------------------------
+// Method:    Exit
+// 
+// Called when this state is popped off the stack.
+//------------------------------------------------------------------------------
+void Kartaclysm::StateMainMenu::Exit()
+{
+	m_bSuspended = false;
+
+	if (m_pGameObjectManager != nullptr)
+	{
+		m_pGameObjectManager->DestroyAllGameObjects();
+		delete m_pGameObjectManager;
+		m_pGameObjectManager = nullptr;
+	}
+}

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateMainMenu.h
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateMainMenu.h
@@ -1,0 +1,43 @@
+//------------------------------------------------------------------------
+// StateMainMenu
+// Author:	Bradley Cooper
+//	
+// Gameplay state first viewed when the game loads.
+//------------------------------------------------------------------------
+
+#ifndef STATE_TEST_H
+#define STATE_TEST_H
+
+#include <functional>
+
+#include "GameplayState.h"
+#include "EventManager.h"
+
+namespace Kartaclysm
+{
+	class StateMainMenu : public Kartaclysm::GameplayState
+	{
+	public:
+		//------------------------------------------------------------------------------
+		// Public methods.
+		//------------------------------------------------------------------------------
+		StateMainMenu();
+		virtual ~StateMainMenu();
+
+		// Inherited
+		void Enter(const std::map<std::string, std::string>& p_mContextParameters);
+		void Suspend(const int p_iNewState);
+		void Unsuspend(const int p_iPrevState);
+		void Update(const float p_fDelta);
+		void PreRender();
+		void Exit();
+
+	protected:
+		// Inherited
+		HeatStroke::GameObjectManager* m_pGameObjectManager;
+		bool m_bSuspended;
+	};
+} // namespace Kartaclysm
+
+#endif
+

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StatePaused.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StatePaused.cpp
@@ -114,6 +114,7 @@ void Kartaclysm::StatePaused::Update(const float p_fDelta)
 	// Do not update when suspended
 	if (!m_bSuspended)
 	{
+		assert(m_pGameObjectManager != nullptr);
 		m_pGameObjectManager->Update(p_fDelta);
 	}
 }
@@ -126,6 +127,7 @@ void Kartaclysm::StatePaused::Update(const float p_fDelta)
 void Kartaclysm::StatePaused::PreRender()
 {
 	// Render even when suspended
+	assert(m_pGameObjectManager != nullptr);
 	m_pGameObjectManager->PreRender();
 }
 

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRacing.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRacing.cpp
@@ -204,6 +204,7 @@ void Kartaclysm::StateRacing::Update(const float p_fDelta)
 	// Do not update when suspended
 	if (!m_bSuspended)
 	{
+		assert(m_pGameObjectManager != nullptr);
 		m_pGameObjectManager->Update(p_fDelta);
 	}
 
@@ -243,6 +244,7 @@ void Kartaclysm::StateRacing::Update(const float p_fDelta)
 void Kartaclysm::StateRacing::PreRender()
 {
 	// Render even when suspended
+	assert(m_pGameObjectManager != nullptr);
 	m_pGameObjectManager->PreRender();
 }
 

--- a/HeatStroke/StateMachine/StateMachine.cpp
+++ b/HeatStroke/StateMachine/StateMachine.cpp
@@ -16,7 +16,9 @@ HeatStroke::StateMachine::StateMachine()
 	:
 	m_mCurrentState(-1, nullptr),
 	m_fCurrentStateTime(0.0f),
-	m_pOwner(nullptr)
+	m_pOwner(nullptr),
+	m_mStateStack(),
+	m_mStateMap()
 {
 }
 
@@ -93,14 +95,14 @@ void HeatStroke::StateMachine::Push(int p_iState, const ContextParameters& p_mCo
 		m_mCurrentState.second->Suspend(it2->first);
 	}
 
-	// Push and enter new state
-	m_mStateStack.push_back(std::pair<int, State*>(p_iState, pState));
-	pState->Enter(p_mContextParameters);
-
 	// Set the new current state info
 	m_mCurrentState.first = p_iState;
 	m_mCurrentState.second = pState;
 	m_fCurrentStateTime = 0.0f;
+
+	// Push and enter new state
+	m_mStateStack.push_back(std::pair<int, State*>(p_iState, pState));
+	pState->Enter(p_mContextParameters);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Just had to switch the order of things in StateMachine::Push(). If Enter() had called Pop(), nothing would have been on the stack to pop and it errored. I also added asserts into the Update and Prerender methods of states to catch a nullptr GameObjectManager.