### PR TITLE
Improved method for determining which racer is ahead

### DIFF
--- a/CS483/CS483/Kartaclysm/Components/ComponentTrack.cpp
+++ b/CS483/CS483/Kartaclysm/Components/ComponentTrack.cpp
@@ -301,36 +301,37 @@ namespace Kartaclysm
 	bool ComponentTrack::IsAhead(ComponentRacer* p_pRacerA, ComponentRacer* p_pRacerB)
 	{
 		// ahead by lap
-		if (p_pRacerA->GetCurrentLap() > p_pRacerB->GetCurrentLap())
+		int iCurrentLapA = p_pRacerA->GetCurrentLap();
+		int iCurrentLapB = p_pRacerB->GetCurrentLap();
+		if (iCurrentLapA > iCurrentLapB)
 		{
 			return true;
 		}
-		else if (p_pRacerA->GetCurrentLap() < p_pRacerB->GetCurrentLap())
+		else if (iCurrentLapA < iCurrentLapB)
 		{
 			return false;
 		}
 		else
 		{
 			// ahead by track piece
-			if (p_pRacerA->GetCurrentTrackPiece() > p_pRacerB->GetCurrentTrackPiece())
+			int iCurrentTrackPieceA = p_pRacerA->GetCurrentTrackPiece();
+			int iCurrentTrackPieceB = p_pRacerB->GetCurrentTrackPiece();
+			if (iCurrentTrackPieceA > iCurrentTrackPieceB)
 			{
 				return true;
 			}
-			else if (p_pRacerA->GetCurrentTrackPiece() < p_pRacerB->GetCurrentTrackPiece())
+			else if (iCurrentTrackPieceA < iCurrentTrackPieceB)
 			{
 				return false;
 			}
 			else
 			{
 				// ahead by distance
-				//TODO: this mathod for determining ahead by distance is not accurate in all cases.
-				int iNextPieceIndex = GetNextTrackPieceIndex(p_pRacerA->GetCurrentTrackPiece());
+				glm::vec3 vRacerPositionA = p_pRacerA->GetGameObject()->GetTransform().GetTranslation();
+				glm::vec3 vRacerPositionB = p_pRacerB->GetGameObject()->GetTransform().GetTranslation();
 
-				glm::vec3 vNextTrackPiecePosition = m_vTrackPieces[iNextPieceIndex]->GetTransform().GetTranslation();
-				glm::vec3 vRacerPosition = p_pRacerA->GetGameObject()->GetTransform().GetTranslation();
-				glm::vec3 vOpponentPosition = p_pRacerB->GetGameObject()->GetTransform().GetTranslation();
-
-				return glm::distance(vNextTrackPiecePosition, vRacerPosition) < glm::distance(vNextTrackPiecePosition, vOpponentPosition);
+				ComponentTrackPiece* pTrackComponent = static_cast<ComponentTrackPiece*>(m_vTrackPieces[iCurrentTrackPieceA]->GetComponent("GOC_TrackPiece"));
+				return pTrackComponent->IsAhead(vRacerPositionA, vRacerPositionB);
 			}
 		}
 	}

--- a/CS483/CS483/Kartaclysm/Components/ComponentTrackPiece.cpp
+++ b/CS483/CS483/Kartaclysm/Components/ComponentTrackPiece.cpp
@@ -8,14 +8,20 @@ namespace Kartaclysm
 		float p_fWidthZ,
 		HeightFunction p_eHeightFunction,
 		float p_fHeight1,
-		float p_fHeight2)
+		float p_fHeight2,
+		PositionFunction p_ePositionFunction,
+		glm::vec3 p_vPivotPosition,
+		glm::vec3 p_vPivotAxis)
 		:
 		Component(p_pGameObject),
 		m_fWidthX(p_fWidthX),
 		m_fWidthZ(p_fWidthZ),
 		m_eHeightFunction(p_eHeightFunction),
 		m_fHeight1(p_fHeight1),
-		m_fHeight2(p_fHeight2)
+		m_fHeight2(p_fHeight2),
+		m_ePositionFunction(p_ePositionFunction),
+		m_vPivotPosition(p_vPivotPosition),
+		m_vPivotAxis(p_vPivotAxis)
 	{
 	}
 
@@ -70,7 +76,16 @@ namespace Kartaclysm
 			}
 		}
 
-		return new ComponentTrackPiece(p_pGameObject, fWidthX, fWidthZ, eHeightFunction, fHeight1, fHeight2);
+		PositionFunction ePositionFunction = ParsePositionFunction(p_pBaseNode);
+		glm::vec3 vPivotPosition;
+		glm::vec3 vPivotAxis;
+		if (ePositionFunction == Turn)
+		{
+			vPivotPosition = ParsePivotPosition(p_pBaseNode);
+			vPivotAxis = ParsePivotAxis(p_pBaseNode);
+		}
+
+		return new ComponentTrackPiece(p_pGameObject, fWidthX, fWidthZ, eHeightFunction, fHeight1, fHeight2, ePositionFunction, vPivotPosition, vPivotAxis);
 	}
 
 	void ComponentTrackPiece::Init()
@@ -137,5 +152,109 @@ namespace Kartaclysm
 				return baseHeight;
 				break;
 		}
+	}
+
+	bool ComponentTrackPiece::IsAhead(const glm::vec3& p_vFirstRacerPosition, const glm::vec3& p_vSecondRacerPosition) const
+	{
+		switch (m_ePositionFunction)
+		{
+			case Straight:
+				return IsAheadOnStraight(p_vFirstRacerPosition, p_vSecondRacerPosition);
+			case Turn:
+				return IsAheadOnTurn(p_vFirstRacerPosition, p_vSecondRacerPosition);
+			default:
+				printf("Unknown position function\n");
+				break;
+		}
+	}
+
+	bool ComponentTrackPiece::IsAheadOnStraight(const glm::vec3& p_vFirstRacerPosition, const glm::vec3& p_vSecondRacerPosition) const
+	{
+		glm::vec4 vPlane = CalculatePlane();
+
+		float fFirstRacerDistance = GetDistanceToPlane(vPlane, p_vFirstRacerPosition);
+		float fSecondRacerDistance = GetDistanceToPlane(vPlane, p_vSecondRacerPosition);
+
+		return fFirstRacerDistance <= fSecondRacerDistance;
+	}
+
+	bool ComponentTrackPiece::IsAheadOnTurn(const glm::vec3& p_vFirstRacerPosition, const glm::vec3& p_vSecondRacerPosition) const
+	{
+		glm::vec3 vPivot = CalculatePivot();
+		glm::vec3 vPivotAxis = CalculatePivotAxis();
+
+		glm::vec3 v1 = glm::normalize(p_vFirstRacerPosition - vPivot);
+		glm::vec3 v2 = glm::normalize(p_vSecondRacerPosition - vPivot);
+
+		return glm::dot(vPivotAxis, v1) <= glm::dot(vPivotAxis, v2);
+	}
+
+	//TODO would be great to calculate this once and store it for all future uses
+	glm::vec4 ComponentTrackPiece::CalculatePlane() const
+	{
+		HeatStroke::HierarchicalTransform trackTransform = m_pGameObject->GetTransform();
+		glm::quat qTrackRotation = trackTransform.GetRotation();
+		qTrackRotation.y *= -1.0f;
+		glm::vec3 vNormal = glm::vec3(1.0f, 0.0f, 0.0f) * qTrackRotation;
+		glm::vec3 vPlaneCenter = trackTransform.GetTranslation() + (glm::vec3(-5.0f, 0.0f, 0.0f) * qTrackRotation);
+		return glm::vec4(vNormal, -(vNormal.x * vPlaneCenter.x) - (vNormal.y * vPlaneCenter.y) - (vNormal.z * vPlaneCenter.z));
+	}
+
+	float ComponentTrackPiece::GetDistanceToPlane(const glm::vec4& p_vPlane, const glm::vec3& p_vPoint) const
+	{
+		return ((p_vPlane.x * p_vPoint.x) + (p_vPlane.y * p_vPoint.y) + (p_vPlane.z * p_vPoint.z) + p_vPlane.w) /
+			(sqrt(pow(p_vPlane.x, 2) + pow(p_vPlane.y, 2) + pow(p_vPlane.z, 2)));
+	}
+
+	//TODO would be great to calculate this once and store it for all future uses
+	glm::vec3 ComponentTrackPiece::CalculatePivot() const
+	{
+		HeatStroke::HierarchicalTransform trackTransform = m_pGameObject->GetTransform();
+		glm::quat qTrackRotation = trackTransform.GetRotation();
+		qTrackRotation.y *= -1.0f;
+		return trackTransform.GetTranslation() + (m_vPivotPosition * qTrackRotation);
+	}
+
+	//TODO would be great to calculate this once and store it for all future uses
+	glm::vec3 ComponentTrackPiece::CalculatePivotAxis() const
+	{
+		HeatStroke::HierarchicalTransform trackTransform = m_pGameObject->GetTransform();
+		glm::quat qTrackRotation = trackTransform.GetRotation();
+		qTrackRotation.y *= -1.0f;
+		return glm::normalize(m_vPivotAxis * qTrackRotation);
+	}
+
+	PositionFunction ComponentTrackPiece::ParsePositionFunction(const tinyxml2::XMLNode* p_pNode)
+	{
+		std::string strHeightFunction = "";
+		HeatStroke::EasyXML::GetRequiredStringAttribute(p_pNode->FirstChildElement("Position"), "function", strHeightFunction);
+		if (strHeightFunction.compare("straight") == 0)
+		{
+			return Straight;
+		}
+		else if (strHeightFunction.compare("turn") == 0)
+		{
+			return Turn;
+		}
+	}
+
+	glm::vec3 ComponentTrackPiece::ParsePivotPosition(const tinyxml2::XMLNode* p_pNode)
+	{
+		glm::vec3 vPivotPosition;
+		const tinyxml2::XMLElement* pPositionElement = p_pNode->FirstChildElement("Position");
+		HeatStroke::EasyXML::GetRequiredFloatAttribute(pPositionElement, "pivotX", vPivotPosition.x);
+		HeatStroke::EasyXML::GetRequiredFloatAttribute(pPositionElement, "pivotY", vPivotPosition.y);
+		HeatStroke::EasyXML::GetRequiredFloatAttribute(pPositionElement, "pivotZ", vPivotPosition.z);
+		return vPivotPosition;
+	}
+
+	glm::vec3 ComponentTrackPiece::ParsePivotAxis(const tinyxml2::XMLNode* p_pNode)
+	{
+		glm::vec3 vPivotAxis;
+		const tinyxml2::XMLElement* pPositionElement = p_pNode->FirstChildElement("Position");
+		HeatStroke::EasyXML::GetRequiredFloatAttribute(pPositionElement, "pivotAxisX", vPivotAxis.x);
+		HeatStroke::EasyXML::GetRequiredFloatAttribute(pPositionElement, "pivotAxisY", vPivotAxis.y);
+		HeatStroke::EasyXML::GetRequiredFloatAttribute(pPositionElement, "pivotAxisZ", vPivotAxis.z);
+		return vPivotAxis;
 	}
 }

--- a/CS483/CS483/Kartaclysm/Components/ComponentTrackPiece.h
+++ b/CS483/CS483/Kartaclysm/Components/ComponentTrackPiece.h
@@ -24,6 +24,12 @@ namespace Kartaclysm
 		Sin3,
 		Sin4
 	};
+
+	enum PositionFunction
+	{
+		Straight,
+		Turn
+	};
 	
 	class ComponentTrackPiece : public HeatStroke::Component
 	{
@@ -44,6 +50,8 @@ namespace Kartaclysm
 			bool CheckInBounds(glm::vec3 p_pPosition);
 			float HeightAtPosition(glm::vec3 p_pPosition);
 
+			bool IsAhead(const glm::vec3& p_vFirstRacerPosition, const glm::vec3& p_vSecondRacerPosition) const;
+
 		protected:
 			ComponentTrackPiece(
 				HeatStroke::GameObject* p_pGameObject,
@@ -51,7 +59,10 @@ namespace Kartaclysm
 				float p_fWidthZ,
 				HeightFunction p_eHeightFunction,
 				float p_fHeight1,
-				float p_fHeight2);
+				float p_fHeight2,
+				PositionFunction p_ePositionFunction,
+				glm::vec3 p_vPivotPosition,
+				glm::vec3 p_vPivotAxis);
 
 		private:
 			float m_fWidthX;
@@ -60,6 +71,22 @@ namespace Kartaclysm
 			HeightFunction m_eHeightFunction;
 			float m_fHeight1;
 			float m_fHeight2;
+
+			PositionFunction m_ePositionFunction;
+			glm::vec3 m_vPivotPosition;
+			glm::vec3 m_vPivotAxis;
+
+			bool IsAheadOnStraight(const glm::vec3& p_vFirstRacerPosition, const glm::vec3& p_vSecondRacerPosition) const;
+			bool IsAheadOnTurn(const glm::vec3& p_vFirstRacerPosition, const glm::vec3& p_vSecondRacerPosition) const;
+
+			glm::vec4 CalculatePlane() const;
+			float GetDistanceToPlane(const glm::vec4& p_vPlane, const glm::vec3& p_vPoint) const;
+			glm::vec3 CalculatePivot() const;
+			glm::vec3 CalculatePivotAxis() const;
+
+			static PositionFunction ParsePositionFunction(const tinyxml2::XMLNode* p_pNode);
+			static glm::vec3 ParsePivotPosition(const tinyxml2::XMLNode* p_pNode);
+			static glm::vec3 ParsePivotAxis(const tinyxml2::XMLNode* p_pNode);
 	};
 }
 

--- a/CS483/CS483/Kartaclysm/Data/Tracks/noob_zone.xml
+++ b/CS483/CS483/Kartaclysm/Data/Tracks/noob_zone.xml
@@ -26,11 +26,13 @@
 		</GameObject>
 		<GameObject guid="03" definition="CS483/CS483/Kartaclysm/Data/Tracks/track_straight.xml">
 			<Transform>
+				<Rotation angle="180" x="0.0" y="1.0" z="0.0" />
 				<Translation x="20.0" y="0.0" z="40.0" />
 			</Transform>
 		</GameObject>
 		<GameObject guid="04" definition="CS483/CS483/Kartaclysm/Data/Tracks/track_straight.xml">
 			<Transform>
+				<Rotation angle="180" x="0.0" y="1.0" z="0.0" />
 				<Translation x="30.0" y="0.0" z="40.0" />
 			</Transform>
 		</GameObject>
@@ -42,25 +44,25 @@
 		</GameObject>
 		<GameObject guid="06" definition="CS483/CS483/Kartaclysm/Data/Tracks/track_straight.xml">
 			<Transform>
-				<Rotation angle="90.0" x="0.0" y="1.0" z="0.0" />
+				<Rotation angle="-90.0" x="0.0" y="1.0" z="0.0" />
 				<Translation x="50.0" y="0.0" z="20.0" />
 			</Transform>
 		</GameObject>
 		<GameObject guid="07" definition="CS483/CS483/Kartaclysm/Data/Tracks/track_straight.xml">
 			<Transform>
-				<Rotation angle="90.0" x="0.0" y="1.0" z="0.0" />
+				<Rotation angle="-90.0" x="0.0" y="1.0" z="0.0" />
 				<Translation x="50.0" y="0.0" z="10.0" />
 			</Transform>
 		</GameObject>
 		<GameObject guid="08" definition="CS483/CS483/Kartaclysm/Data/Tracks/track_straight.xml">
 			<Transform>
-				<Rotation angle="90.0" x="0.0" y="1.0" z="0.0" />
+				<Rotation angle="-90.0" x="0.0" y="1.0" z="0.0" />
 				<Translation x="50.0" y="0.0" z="0.0" />
 			</Transform>
 		</GameObject>
 		<GameObject guid="09" definition="CS483/CS483/Kartaclysm/Data/Tracks/track_straight.xml">
 			<Transform>
-				<Rotation angle="90.0" x="0.0" y="1.0" z="0.0" />
+				<Rotation angle="-90.0" x="0.0" y="1.0" z="0.0" />
 				<Translation x="50.0" y="0.0" z="-10.0" />
 			</Transform>
 		</GameObject>

--- a/CS483/CS483/Kartaclysm/Data/Tracks/track_finish.xml
+++ b/CS483/CS483/Kartaclysm/Data/Tracks/track_finish.xml
@@ -6,6 +6,7 @@
     <GOC_TrackPiece>
       <Bounds widthX="10" widthZ="10"/>
       <Height function="flat"/>
+      <Position function="straight"/>
     </GOC_TrackPiece>
 	</Components>
 

--- a/CS483/CS483/Kartaclysm/Data/Tracks/track_jump.xml
+++ b/CS483/CS483/Kartaclysm/Data/Tracks/track_jump.xml
@@ -6,6 +6,7 @@
     <GOC_TrackPiece>
       <Bounds widthX="10" widthZ="10"/>
       <Height function="linear" height1="0.0" height2="2.0"/>
+      <Position function="straight"/>
     </GOC_TrackPiece>
 	</Components>
 

--- a/CS483/CS483/Kartaclysm/Data/Tracks/track_ramp_down_flat.xml
+++ b/CS483/CS483/Kartaclysm/Data/Tracks/track_ramp_down_flat.xml
@@ -6,6 +6,7 @@
     <GOC_TrackPiece>
       <Bounds widthX="10" widthZ="10"/>
       <Height function="sin3" height1="1.0" height2="0.0"/>
+      <Position function="straight"/>
     </GOC_TrackPiece>
 	</Components>
 

--- a/CS483/CS483/Kartaclysm/Data/Tracks/track_ramp_flat_down.xml
+++ b/CS483/CS483/Kartaclysm/Data/Tracks/track_ramp_flat_down.xml
@@ -6,6 +6,7 @@
     <GOC_TrackPiece>
       <Bounds widthX="10" widthZ="10"/>
       <Height function="sin2" height1="1.0" height2="0.0"/>
+      <Position function="straight"/>
     </GOC_TrackPiece>
 	</Components>
 

--- a/CS483/CS483/Kartaclysm/Data/Tracks/track_ramp_flat_up.xml
+++ b/CS483/CS483/Kartaclysm/Data/Tracks/track_ramp_flat_up.xml
@@ -6,6 +6,7 @@
     <GOC_TrackPiece>
       <Bounds widthX="10" widthZ="10"/>
       <Height function="sin4" height1="0.0" height2="1.0"/>
+      <Position function="straight"/>
     </GOC_TrackPiece>
 	</Components>
 

--- a/CS483/CS483/Kartaclysm/Data/Tracks/track_ramp_up_flat.xml
+++ b/CS483/CS483/Kartaclysm/Data/Tracks/track_ramp_up_flat.xml
@@ -6,6 +6,7 @@
     <GOC_TrackPiece>
       <Bounds widthX="10" widthZ="10"/>
       <Height function="sin1" height1="0.0" height2="1.0"/>
+      <Position function="straight"/>
     </GOC_TrackPiece>
 	</Components>
 

--- a/CS483/CS483/Kartaclysm/Data/Tracks/track_straight.xml
+++ b/CS483/CS483/Kartaclysm/Data/Tracks/track_straight.xml
@@ -6,6 +6,7 @@
     <GOC_TrackPiece>
       <Bounds widthX="10" widthZ="10"/>
       <Height function="flat"/>
+      <Position function="straight"/>
     </GOC_TrackPiece>
 	</Components>
 

--- a/CS483/CS483/Kartaclysm/Data/Tracks/track_turn_left_large.xml
+++ b/CS483/CS483/Kartaclysm/Data/Tracks/track_turn_left_large.xml
@@ -6,6 +6,7 @@
     <GOC_TrackPiece>
       <Bounds widthX="20" widthZ="20"/>
       <Height function="flat"/>
+      <Position function="turn" pivotX="10.0" pivotY="0.0" pivotZ="10.0" pivotAxisX="0.0" pivotAxisY="0.0" pivotAxisZ="-1.0"/>
     </GOC_TrackPiece>
 	</Components>
 

--- a/CS483/CS483/Kartaclysm/Data/Tracks/track_turn_left_small.xml
+++ b/CS483/CS483/Kartaclysm/Data/Tracks/track_turn_left_small.xml
@@ -6,6 +6,7 @@
     <GOC_TrackPiece>
       <Bounds widthX="10" widthZ="10"/>
       <Height function="flat"/>
+      <Position function="turn" pivotX="5.0" pivotY="0.0" pivotZ="5.0" pivotAxisX="0.0" pivotAxisY="0.0" pivotAxisZ="-1.0"/>
     </GOC_TrackPiece>
 	</Components>
 

--- a/CS483/CS483/Kartaclysm/Data/Tracks/track_turn_right_large.xml
+++ b/CS483/CS483/Kartaclysm/Data/Tracks/track_turn_right_large.xml
@@ -6,6 +6,7 @@
     <GOC_TrackPiece>
       <Bounds widthX="20" widthZ="20"/>
       <Height function="flat"/>
+      <Position function="turn" pivotX="10.0" pivotY="0.0" pivotZ="-10.0" pivotAxisX="0.0" pivotAxisY="0.0" pivotAxisZ="1.0"/>
     </GOC_TrackPiece>
 	</Components>
 

--- a/CS483/CS483/Kartaclysm/Data/Tracks/track_turn_right_small.xml
+++ b/CS483/CS483/Kartaclysm/Data/Tracks/track_turn_right_small.xml
@@ -6,6 +6,7 @@
     <GOC_TrackPiece>
       <Bounds widthX="10" widthZ="10"/>
       <Height function="flat"/>
+      <Position function="turn" pivotX="5.0" pivotY="0.0" pivotZ="-5.0" pivotAxisX="0.0" pivotAxisY="0.0" pivotAxisZ="1.0"/>
     </GOC_TrackPiece>
 	</Components>
 

--- a/CS483/CS483/Kartaclysm/Data/Tracks/up_and_over.xml
+++ b/CS483/CS483/Kartaclysm/Data/Tracks/up_and_over.xml
@@ -30,7 +30,6 @@
 		</GameObject>
 		<GameObject guid="04" definition="CS483/CS483/Kartaclysm/Data/Tracks/track_straight_underjump.xml">
 			<Transform>
-				<Rotation angle="180.0" x="0.0" y="1.0" z="0.0" />
 				<Translation x="-40.0" y="-2.0" z="30.0" />
 			</Transform>
 		</GameObject>
@@ -69,6 +68,7 @@
 		</GameObject>
 		<GameObject guid="11" definition="CS483/CS483/Kartaclysm/Data/Tracks/track_straight.xml">
 			<Transform>
+				<Rotation angle="180" x="0.0" y="1.0" z="0.0" />
 				<Translation x="-60.0" y="2.0" z="80.0" />
 			</Transform>
 		</GameObject>
@@ -122,6 +122,7 @@
 		</GameObject>
 		<GameObject guid="20" definition="CS483/CS483/Kartaclysm/Data/Tracks/track_straight.xml">
 			<Transform>
+				<Rotation angle="180" x="0.0" y="1.0" z="0.0" />
 				<Translation x="-20.0" y="0.0" z="-20.0" />
 			</Transform>
 		</GameObject>


### PR DESCRIPTION
Tried making the changes noted in the TODOs in ComponentTrackPiece.cpp, but it didn't work, presumably because of the transform on the pieces.  Will want to explore it later, as it's an obvious efficiency improvement, but not causing any issues yet, so not a worry.