### PR TITLE
Bugfix/hierarchy delete

### DIFF
--- a/HeatStroke/GOComponents/GameObject.cpp
+++ b/HeatStroke/GOComponents/GameObject.cpp
@@ -44,11 +44,9 @@ GameObject::GameObject(GameObjectManager* p_pGameObjectManager, const std::strin
 //------------------------------------------------------------------------------
 GameObject::~GameObject()
 {
-	// TODO - I don't know what's happening, but it's started throwing errors again when trying to remove itself as a child from its parent.
-	//			I'm removing this for now so it doesn't throw errors, but I'll need to figure this out soon.
-
 	DeleteAllComponents();
 	DeleteAllChildren();
+	SetParent(nullptr);
 }
 
 //------------------------------------------------------------------------------
@@ -193,6 +191,7 @@ void GameObject::DeleteAllChildren()
 {
 	for (ChildMap::iterator it = m_mChildMap.begin(); it != m_mChildMap.end(); ++it)
 	{
+		it->second->m_pParent = nullptr;
 		m_pGameObjectManager->DestroyGameObject(it->second);
 	}
 	m_mChildMap.clear();

--- a/HeatStroke/GOComponents/GameObjectManager.cpp
+++ b/HeatStroke/GOComponents/GameObjectManager.cpp
@@ -244,13 +244,29 @@ void GameObjectManager::Update(const float p_fDelta)
 	std::set<GameObject*>::iterator delete_it = m_vToDelete.begin(), delete_end = m_vToDelete.end();
 	for (; delete_it != delete_end;)
 	{
+		if ((*delete_it) == nullptr)
+		{
+#ifdef _DEBUG
+			assert(false && "Attempting to delete nullptr");
+#endif
+			delete_it = m_vToDelete.erase(delete_it);
+			continue;
+		}
+
 		GameObjectMap::iterator it = m_mGameObjectMap.find((*delete_it)->GetGUID());
 		
 		if (it != m_mGameObjectMap.end())
 		{
 			delete it->second;
+			it->second = nullptr;
 			m_mGameObjectMap.erase(it);
 		}
+#ifdef _DEBUG
+		else
+		{
+			assert(false && "Could not find GameObject to delete.");
+		}
+#endif
 
 		delete_it = m_vToDelete.erase(delete_it);
 	}


### PR DESCRIPTION
Another TODO issue addressed with GameObject hierarchy during deconstruction.

Added additional nullptr protection to GameObjects queued for destruction.