### PR TITLE
Restart not selectable during tournaments

### DIFF
--- a/CS483/CS483/Kartaclysm/Data/Menus/PauseMenu/pause_options.xml
+++ b/CS483/CS483/Kartaclysm/Data/Menus/PauseMenu/pause_options.xml
@@ -1,7 +1,7 @@
 <GameObject>
 	<Children>
     <!-- Pause Message -->
-    <GameObject>
+    <GameObject guid="title">
       <Transform>
         <Translation x="-202.0" y="75.0" z="1.0" />
         <Scale x="40.0" y="25.0" z="1.0" />
@@ -15,7 +15,7 @@
     </GameObject>
     
 		<!-- Continue -->
-		<GameObject>
+		<GameObject guid="continue">
 			<Transform>
 				<Translation x="-224.0" y="20.0" z="1.0"/>
 				<Scale x="0.5" y="0.5" z="1.0"/>
@@ -31,7 +31,7 @@
 		</GameObject>
 
     <!-- Options -->
-    <GameObject>
+    <GameObject guid="options">
       <Transform>
         <Translation x="-224.0" y="-10.0" z="1.0"/>
         <Scale x="0.5" y="0.5" z="1.0"/>
@@ -47,7 +47,7 @@
     </GameObject>
 
     <!-- Restart -->
-    <GameObject>
+    <GameObject guid="restart">
       <Transform>
         <Translation x="-222.0" y="-40.0" z="1.0"/>
         <Scale x="0.5" y="0.5" z="1.0"/>
@@ -63,7 +63,7 @@
     </GameObject>
 
     <!-- Quit -->
-    <GameObject>
+    <GameObject guid="quit">
       <Transform>
         <Translation x="-211.0" y="-70.0" z="1.0"/>
         <Scale x="0.5" y="0.5" z="1.0"/>

--- a/CS483/CS483/Kartaclysm/Services/IO/PlayerInputMapping.cpp
+++ b/CS483/CS483/Kartaclysm/Services/IO/PlayerInputMapping.cpp
@@ -329,26 +329,22 @@ namespace Kartaclysm
 	bool PlayerInputMapping::SetSplitscreenPlayers(const int p_iNumPlayers)
 	{
 		m_iPlayersRacing = p_iNumPlayers;
-		int iAssigned = m_iPlayersConnected;
+		int iAlreadyConnected = m_iPlayersConnected;
 
 		int iLimit = (p_iNumPlayers > m_iPlayersConnected ? p_iNumPlayers : m_iPlayersConnected);
 		for (int i = 0; i < iLimit; i++)
 		{
-			if (i < iAssigned)
+			if (i < iAlreadyConnected)
 			{
 				SendInputAssignmentEvent(i);
 			}
-			else if (i > p_iNumPlayers)
+			else
 			{
-				AssignInput(i, -1);
-			}
-			else if (!AssignInput(i, GetFirstAvailableInput()))
-			{
-				m_iPlayersRacing--;
+				AssignInput(i, GetFirstAvailableInput());
 			}
 		}
 
-		return m_iPlayersConnected == m_iPlayersRacing;
+		return m_iPlayersConnected >= m_iPlayersRacing;
 	}
 
 	//--------------------------------------------------------------------------------

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateCountdown.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateCountdown.cpp
@@ -103,5 +103,5 @@ void Kartaclysm::StateCountdown::Exit()
 		m_pGameObjectManager = nullptr;
 	}
 
-	m_bSuspended = false;
+	m_bSuspended = true;
 }

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateMainMenu.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateMainMenu.cpp
@@ -91,7 +91,7 @@ void Kartaclysm::StateMainMenu::PreRender()
 
 void Kartaclysm::StateMainMenu::Exit()
 {
-	m_bSuspended = false;
+	m_bSuspended = true;
 
 	if (m_pGameObjectManager != nullptr)
 	{

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateModeSelectionMenu.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateModeSelectionMenu.cpp
@@ -71,18 +71,21 @@ void Kartaclysm::StateModeSelectionMenu::Update(const float p_fDelta)
 
 		if (bConfirm)
 		{
+			std::map<std::string, std::string> mContextParameters;
 			switch (m_iModeSelection)
 			{
 			case 0:
 				m_pStateMachine->Pop();
-				m_pStateMachine->Push(STATE_PLAYER_SELECTION_MENU);
+				mContextParameters["Mode"] = "Single";
+				m_pStateMachine->Push(STATE_PLAYER_SELECTION_MENU, mContextParameters);
 				break;
 			case 1:
 				m_pStateMachine->Pop();
-				m_pStateMachine->Push(STATE_TOURNAMENT);
+				mContextParameters["Mode"] = "Tournament";
+				m_pStateMachine->Push(STATE_TOURNAMENT, mContextParameters);
 				break;
 			case 2:
-				m_pStateMachine->Push(STATE_OPTIONS_MENU);
+				m_pStateMachine->Push(STATE_OPTIONS_MENU, mContextParameters);
 				break;
 			}
 		}
@@ -130,7 +133,7 @@ void Kartaclysm::StateModeSelectionMenu::PreRender()
 
 void Kartaclysm::StateModeSelectionMenu::Exit()
 {
-	m_bSuspended = false;
+	m_bSuspended = true;
 
 	if (m_pGameObjectManager != nullptr)
 	{

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateOptionsMenu.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateOptionsMenu.cpp
@@ -182,7 +182,7 @@ void Kartaclysm::StateOptionsMenu::PreRender()
 
 void Kartaclysm::StateOptionsMenu::Exit()
 {
-	m_bSuspended = false;
+	m_bSuspended = true;
 
 	if (m_pGameObjectManager != nullptr)
 	{

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StatePaused.h
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StatePaused.h
@@ -39,10 +39,13 @@ namespace Kartaclysm
 		bool m_bSuspended;
 
 	private:
+		std::map<std::string, std::string> m_mContextParameters;
+
 		int m_iPausedPlayer;
 		int m_iOptionSelection;
 		HeatStroke::GameObject* m_pCurrentHighlight;
 		bool m_bSkipFirstFrame;
+		bool m_bTournament;
 	};
 }
 

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StatePlayerSelectionMenu.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StatePlayerSelectionMenu.cpp
@@ -368,7 +368,7 @@ void Kartaclysm::StatePlayerSelectionMenu::PreRender()
 
 void Kartaclysm::StatePlayerSelectionMenu::Exit()
 {
-	m_bSuspended = false;
+	m_bSuspended = true;
 
 	if (m_pGameObjectManager != nullptr)
 	{
@@ -414,7 +414,6 @@ void Kartaclysm::StatePlayerSelectionMenu::GoToTrackSelectionState()
 {
 	PlayerInputMapping::Instance()->SetSplitscreenPlayers(m_uiNumPlayers);
 
-	std::map<std::string, std::string> m_mContextParameters;
 	m_mContextParameters.insert(std::pair<std::string, std::string>("PlayerCount", std::to_string(m_uiNumPlayers)));
 
 	for (unsigned int i = 0; i < m_uiNumPlayers; i++)

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRaceCompleteMenu.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRaceCompleteMenu.cpp
@@ -33,17 +33,19 @@ void Kartaclysm::StateRaceCompleteMenu::Enter(const std::map<std::string, std::s
 
 	m_pGameObjectManager->CreateGameObject("CS483/CS483/Kartaclysm/Data/Menus/RaceCompleteMenu/race_complete_message.xml");
 
-	if (p_mContextParameters.find("tournament") != p_mContextParameters.end())
+	std::string strMode = p_mContextParameters.at("Mode");
+	if (strMode == "Tournament")
 	{
-		if (HeatStroke::ComponentTextBox* pTitle = dynamic_cast<HeatStroke::ComponentTextBox*>(m_pGameObjectManager->GetGameObject("title")->GetComponent("GOC_Renderable")))
-		{
-			pTitle->SetMessage("Tournament");
-		}
+		dynamic_cast<HeatStroke::ComponentTextBox*>(m_pGameObjectManager->GetGameObject("title")->GetComponent("GOC_Renderable"))->SetMessage("Tournament");
 	}
-	else
+	else if (strMode == "Single")
 	{
 		SendRaceFinishEvent(p_mContextParameters);
 		RecordBestTime(p_mContextParameters, "CS483/CS483/Kartaclysm/Data/DevConfig/FastestTimes.xml");
+	}
+	else
+	{
+		assert(false && "Unknown mode");
 	}
 
 	PopulateRaceResultsList(p_mContextParameters);

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRaceCompleteMenu.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRaceCompleteMenu.cpp
@@ -87,7 +87,7 @@ void Kartaclysm::StateRaceCompleteMenu::PreRender()
 
 void Kartaclysm::StateRaceCompleteMenu::Exit()
 {
-	m_bSuspended = false;
+	m_bSuspended = true;
 
 	if (m_pGameObjectManager != nullptr)
 	{

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRacing.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRacing.cpp
@@ -282,7 +282,7 @@ void Kartaclysm::StateRacing::PreRender()
 
 void Kartaclysm::StateRacing::Exit()
 {
-	m_bSuspended = false;
+	m_bSuspended = true;
 
 	PlayerInputMapping::Instance()->DisableRaceMode();
 
@@ -333,6 +333,7 @@ void Kartaclysm::StateRacing::PauseGame(const HeatStroke::Event* p_pEvent)
 	// Create context for pushing to pause state
 	HeatStroke::StateMachine::ContextParameters mContext = HeatStroke::StateMachine::ContextParameters();
 	mContext["Player"] = std::to_string(iPlayer);
+	mContext["Mode"] = m_mContextParams.at("Mode");
 
 	// Push pause state
 	m_pStateMachine->Push(STATE_PAUSED, mContext);

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRacing.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRacing.cpp
@@ -378,6 +378,7 @@ std::map<std::string, std::string> Kartaclysm::StateRacing::GenerateRaceResults(
 
 	std::string strTrack = static_cast<ComponentTrack*>(m_pGameObjectManager->GetGameObject("Track")->GetComponent("GOC_Track"))->GetTrackName();
 	mRaceResults.insert(std::pair<std::string, std::string>("trackName", strTrack));
+	mRaceResults.insert(std::pair<std::string, std::string>("Mode", "Single"));
 
 	return mRaceResults;
 }

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateTournament.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateTournament.cpp
@@ -12,7 +12,7 @@ Kartaclysm::StateTournament::StateTournament()
 	GameplayState("Tournament State"),
 	m_pGameObjectManager(nullptr),
 	m_bSuspended(true),
-	m_bReadyToPush(false),
+	m_bReadyForNextRace(false),
 	m_bFinished(false),
 	m_uiRaceCount(0),
 	m_mContextParams(),
@@ -32,7 +32,7 @@ Kartaclysm::StateTournament::~StateTournament()
 void Kartaclysm::StateTournament::Enter(const std::map<std::string, std::string>& p_mContextParameters)
 {
 	m_bSuspended = false;
-	m_bReadyToPush = false;
+	m_bReadyForNextRace = false;
 	m_bFinished = false;
 	m_uiRaceCount = 0;
 	m_mContextParams = p_mContextParameters;
@@ -55,9 +55,9 @@ void Kartaclysm::StateTournament::Update(const float p_fDelta)
 	// Do not update when suspended
 	if (!m_bSuspended)
 	{
-		if (m_bReadyToPush)
+		if (m_bReadyForNextRace)
 		{
-			m_bReadyToPush = false;
+			m_bReadyForNextRace = false;
 			m_pStateMachine->Push(STATE_RACING, m_mContextParams);
 		}
 		else if (m_bFinished)
@@ -65,6 +65,7 @@ void Kartaclysm::StateTournament::Update(const float p_fDelta)
 			m_bFinished = false;
 			m_pStateMachine->Pop();
 			m_pStateMachine->Push(STATE_RACE_COMPLETE_MENU, m_mContextParams);
+			// TODO: Show some kind of congratulations screen?
 		}
 		else
 		{
@@ -137,14 +138,14 @@ void Kartaclysm::StateTournament::RaceFinishCallback(const HeatStroke::Event* p_
 	if (++m_uiRaceCount < m_vTracks.size())
 	{
 		m_mContextParams["TrackDefinitionFile"] = m_vTracks[m_uiRaceCount];
-		m_bReadyToPush = true;
+		m_bReadyForNextRace = true;
 	}
 	else
 	{
 		m_bFinished = true;
 		m_mContextParams.clear();
+		m_mContextParams["Mode"] = "Tournament";
 		m_mContextParams["numRacers"] = std::to_string(m_mRacerRankings.size());
-		m_mContextParams["tournament"] = std::to_string(m_vTracks.size());
 
 		int iRank = 0;
 		while (!m_mRacerRankings.empty())

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateTournament.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateTournament.cpp
@@ -35,8 +35,8 @@ void Kartaclysm::StateTournament::Enter(const std::map<std::string, std::string>
 	m_bReadyToPush = false;
 	m_bFinished = false;
 	m_uiRaceCount = 0;
+	m_mContextParams = p_mContextParameters;
 	m_mRacerRankings.clear();
-	m_mContextParams.clear();
 
 	m_pRaceFinishDelegate = new std::function<void(const HeatStroke::Event*)>(std::bind(&StateTournament::RaceFinishCallback, this, std::placeholders::_1));
 	HeatStroke::EventManager::Instance()->AddListener("RaceFinish", m_pRaceFinishDelegate);
@@ -46,9 +46,8 @@ void Kartaclysm::StateTournament::Enter(const std::map<std::string, std::string>
 
 	// Shuffle tracks for tournament and push to player selection
 	std::random_shuffle(m_vTracks.begin(), m_vTracks.end());
-	std::map<std::string, std::string> mContextParams;
-	mContextParams["TrackDefinitionFile"] = m_vTracks[0];
-	m_pStateMachine->Push(STATE_PLAYER_SELECTION_MENU, mContextParams);
+	m_mContextParams["TrackDefinitionFile"] = m_vTracks[0];
+	m_pStateMachine->Push(STATE_PLAYER_SELECTION_MENU, m_mContextParams);
 }
 
 void Kartaclysm::StateTournament::Update(const float p_fDelta)
@@ -78,7 +77,7 @@ void Kartaclysm::StateTournament::Update(const float p_fDelta)
 
 void Kartaclysm::StateTournament::Exit()
 {
-	m_bSuspended = false;
+	m_bSuspended = true;
 
 	if (m_pGameObjectManager != nullptr)
 	{

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateTournament.h
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateTournament.h
@@ -41,8 +41,8 @@ namespace Kartaclysm
 			int		m_iPoints;
 			float	m_fTime;
 		};
-
-		bool m_bReadyToPush;
+		
+		bool m_bReadyForNextRace;
 		bool m_bFinished;
 		unsigned int m_uiRaceCount;
 		std::vector<std::string> m_vTracks;

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateTrackSelectionMenu.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateTrackSelectionMenu.cpp
@@ -168,7 +168,7 @@ void Kartaclysm::StateTrackSelectionMenu::PreRender()
 
 void Kartaclysm::StateTrackSelectionMenu::Exit()
 {
-	m_bSuspended = false;
+	m_bSuspended = true;
 
 	if (m_pGameObjectManager != nullptr)
 	{

--- a/HeatStroke/StateMachine/StateMachine.cpp
+++ b/HeatStroke/StateMachine/StateMachine.cpp
@@ -165,7 +165,8 @@ void HeatStroke::StateMachine::Update(const float p_fDelta, const bool m_bUpdate
 	if (m_bUpdateStack)
 	{
 		// Update entire stack from bottom to top
-		StateStack::iterator it = m_mStateStack.begin(), end = m_mStateStack.end();
+		StateStack mLocalCopy(m_mStateStack);
+		StateStack::iterator it = mLocalCopy.begin(), end = mLocalCopy.end();
 		for (; it != end; it++)
 		{
 			it->second->Update(p_fDelta);


### PR DESCRIPTION
Two other bugfixes as they arose:

- State stack needed a local copy made for cases where states were popped or pushed during an update. Also the reason that m_bSuspended is set to true in Exit() methods now

- SetSplitScreenPlayers() needed to change the return value to be (>=) rather than (==) because the menu needs to have 4 players to work. Also removed disconnecting players for this reason.