### PR TITLE
Fix a bug where player can be removed from m_vRacers

### DIFF
--- a/CS483/CS483/Kartaclysm/Components/ComponentTrack.cpp
+++ b/CS483/CS483/Kartaclysm/Components/ComponentTrack.cpp
@@ -225,8 +225,8 @@ namespace Kartaclysm
 		bool bRaceStandingsUpdate = false;
 		for (unsigned int i = 1; i < m_vRacers.size(); ++i)
 		{
-			ComponentRacer* racerA = m_vRacers[i];
-			if (racerA->HasFinishedRace())
+			ComponentRacer* pOriginalRacer = m_vRacers[i];
+			if (m_vRacers[i]->HasFinishedRace())
 			{
 				continue;
 			}
@@ -234,20 +234,20 @@ namespace Kartaclysm
 			bool bRacerPositionUpdated = false;
 			for (int j = i - 1; j >= 0; --j)
 			{
-				ComponentRacer* racerB = m_vRacers[j];
-				if (IsAhead(racerA, racerB))
+				if (IsAhead(m_vRacers[i], m_vRacers[j]))
 				{
-					m_vRacers[i] = racerB;
-					m_vRacers[j] = racerA;
+					ComponentRacer* pTemp = m_vRacers[j];
+					m_vRacers[j] = m_vRacers[i];
+					m_vRacers[i] = pTemp;
 					bRacerPositionUpdated = true;
 					bRaceStandingsUpdate = true;
-					TriggerRacerPositionUpdateEvent(racerB->GetGameObject()->GetGUID());
+					TriggerRacerPositionUpdateEvent(pTemp->GetGameObject()->GetGUID());
 				}
 			}
 
 			if (bRacerPositionUpdated)
 			{
-				TriggerRacerPositionUpdateEvent(racerA->GetGameObject()->GetGUID());
+				TriggerRacerPositionUpdateEvent(pOriginalRacer->GetGameObject()->GetGUID());
 			}
 		}
 


### PR DESCRIPTION
When two players pass the player in first place, one of the players can be removed from m_vRacers causing a required parameter to be missing on dispatched event.

Specifically, error is caused any iteration after the second iteration of the second loop (i == 2, j == 0). The variable RacerA may point to a different racer than m_vRacer[i] because it didn't update with the previous iteration's swap. Thus, RacerA (which hasn't changed) may then be assigned to m_vRacer[j], meaning RacerA is now assigned to two different positions and one of the racers is lost.