### PR TITLE
Armor ability now negates other abilities

### DIFF
--- a/CS483/CS483/Kartaclysm/Components/Abilities/ComponentAbilityConditions.cpp
+++ b/CS483/CS483/Kartaclysm/Components/Abilities/ComponentAbilityConditions.cpp
@@ -20,11 +20,11 @@ namespace Kartaclysm
 		m_pGameObject(p_pGameObject),
 		m_strEventName(p_strAbility),
 		m_fMaxCooldown(p_fCooldown),
-		m_fCurrentCooldown(p_fCooldown),
+		m_fCurrentCooldown(p_fCooldown > 0.0f ? p_fCooldown : p_fCooldown + 3.0f), // beginning race countdown
 		m_iMaxCharges(p_iMaxCharges),
 		m_iCurrentCharges(p_iStartCharges),
 		m_bSpecial(true),
-		m_bSendEvent(false)
+		m_bSendEvent(true)
 	{
 	}
 

--- a/CS483/CS483/Kartaclysm/Components/Abilities/ComponentArmorPlateAbility.cpp
+++ b/CS483/CS483/Kartaclysm/Components/Abilities/ComponentArmorPlateAbility.cpp
@@ -60,7 +60,6 @@ namespace Kartaclysm
 		// Find ability conditions component
 		m_pConditions = static_cast<ComponentAbilityConditions*>(GetGameObject()->GetComponent("GOC_AbilityConditions"));
 		assert(m_pConditions != nullptr && "Cannot find component.");
-		m_pConditions->ResetCooldown(); // quick-fix to send HUD event to display charges
 		
 	}
 
@@ -68,15 +67,17 @@ namespace Kartaclysm
 	{
 		if (!m_bSentImmuneEvent && m_pConditions->CanActivate())
 		{
-			m_bSentImmuneEvent = true;
 			Activate();
 		}
 	}
 
 	void ComponentArmorPlateAbility::Activate()
 	{
+		m_bSentImmuneEvent = true;
+		m_pConditions->ResetCooldown();
+
 		// Send immunity event for kart controller
-		HeatStroke::Event* pEvent = new HeatStroke::Event("Ability");
+		HeatStroke::Event* pEvent = new HeatStroke::Event("AbilityUse");
 		pEvent->SetStringParameter("Originator", m_strPlayerX);
 		pEvent->SetStringParameter("Ability", "Immune");
 		pEvent->SetStringParameter("ListenEvent", m_strChargeEventName);
@@ -105,12 +106,12 @@ namespace Kartaclysm
 			iChange--;
 			m_pConditions->RemoveCharge();
 			m_pConditions->ResetCooldown();
+			m_bSentImmuneEvent = false;
 		}
 
 		if (iChange != 0)
 		{
 			// Charge count changed: send armor plate event for kart controller (changes stats)
-			//HeatStroke::Event* pEvent = new HeatStroke::Event("Ability");
 			HeatStroke::Event* pEvent = new HeatStroke::Event("AbilityUse"); // I don't think this is right, but it works (Brad, ya dingus)
 			pEvent->SetStringParameter("Originator", m_strPlayerX);
 			pEvent->SetStringParameter("Ability", "ArmorPlate");

--- a/CS483/CS483/Kartaclysm/Components/ComponentKartController.cpp
+++ b/CS483/CS483/Kartaclysm/Components/ComponentKartController.cpp
@@ -709,12 +709,18 @@ namespace Kartaclysm
 	void ComponentKartController::HandleAbilityEvent(const HeatStroke::Event* p_pEvent)
 	{
 		// TODO: make this use game objects (brad, ya dingus)
-		std::string originator, target = "";
+		std::string originator, ability, target = "";
 		float power = 0.0f, duration = 0.0f;
 		p_pEvent->GetRequiredStringParameter("Originator", originator);
+		p_pEvent->GetRequiredStringParameter("Ability", ability);
 		p_pEvent->GetOptionalStringParameter("Target", target, target);
 		p_pEvent->GetOptionalFloatParameter("Power", power, power);
 		p_pEvent->GetOptionalFloatParameter("Duration", duration, duration);
+
+#ifdef _DEBUG
+		printf("KartController: Ability %s from %s targetting %s\n", 
+			ability.c_str(), originator.c_str(), target == "" ? "self" : target.c_str());
+#endif
 
 		if (target.compare(m_pGameObject->GetGUID()) == 0)
 		{
@@ -724,69 +730,53 @@ namespace Kartaclysm
 				HeatStroke::Event* pEvent = new HeatStroke::Event(m_strHitCallback);
 				pEvent->SetIntParameter("Negated", 1);
 				HeatStroke::EventManager::Instance()->TriggerEvent(pEvent);
-				printf("->Negated");
 
 				m_strHitCallback = "";
 				return;
 			}
 
-			std::string ability, effect;
-			p_pEvent->GetRequiredStringParameter("Ability", ability);
+			std::string effect;
 			p_pEvent->GetRequiredStringParameter("Effect", effect);
 
 			if (ability.compare("Strike") == 0)
 			{
-				printf("Strike!\n");
 				HeatStroke::AudioPlayer::Instance()->PlaySoundEffect("Assets/Sounds/kingpin_strike_hit.wav");
 				Spinout(duration);
 			}
 			else if (ability.compare("Clock") == 0)
 			{
-				printf("Clocked!\n");
 				Spinout(duration);
 			}
 			else if (ability.compare("Rain") == 0)
 			{
-				printf("Make it rain!\n");
-
 				// Send event for HUD
 				HeatStroke::Event* pEvent = new HeatStroke::Event(target + "_HUD_Slow");
 				pEvent->SetIntParameter("Display", 1);
 				HeatStroke::EventManager::Instance()->TriggerEvent(pEvent);
 
 				HeatStroke::AudioPlayer::Instance()->PlaySoundEffect("Assets/Sounds/cleopapa_make_it_rain.wav");
-
 				Slow(power, duration);
 			}
 			else if (ability.compare("Bedazzle") == 0)
 			{
-				printf("Bedazzle!\n"); // Entangle!
-
 				HeatStroke::AudioPlayer::Instance()->PlaySoundEffect("Assets/Sounds/cleopapa_bedazzle.wav");
-
 				Spinout(duration);
 			}
 		}
 		else if (originator.compare(m_pGameObject->GetGUID()) == 0)
 		{
-			std::string ability;
-			p_pEvent->GetRequiredStringParameter("Ability", ability);
-
 			if (ability.compare("Boost") == 0)
 			{
-				printf("Boost!\n");
 				HeatStroke::AudioPlayer::Instance()->PlaySoundEffect("Assets/Sounds/speedster_boost.flac");
 				Boost(power);
 			}
 			else if (ability.compare("Wheelie") == 0)
 			{
-				printf("Wheelie!\n");
 				HeatStroke::AudioPlayer::Instance()->PlaySoundEffect("Assets/Sounds/showoff_wheelie.wav");
 				WheelieToggle();
 			}
 			else if (ability.compare("Tinker") == 0)
 			{
-				printf("Tinker!\n"); // "More like tinker bell" (really brad? really? ya dingus)
 				HeatStroke::AudioPlayer::Instance()->PlaySoundEffect("Assets/Sounds/clockmaker_tinker.wav");
 				TurnLock(duration);
 			}
@@ -796,7 +786,6 @@ namespace Kartaclysm
 				p_pEvent->GetRequiredIntParameter("Layers", iLayers);
 				p_pEvent->GetRequiredIntParameter("MaxLayers", iMax);
 
-				printf("ArmorPlate!\n");
 				HeatStroke::AudioPlayer::Instance()->PlaySoundEffect("Assets/Sounds/juggernaut_armor.wav");
 				ArmorPlate(iLayers);
 			}


### PR DESCRIPTION
Simple bugfix caused by a String used to create the event.

Also added 3s to initial ability cooldown timers for the beginning race countdown (Clockmaker could activate Tinker) and streamlined debug output for abilities.