### PR TITLE
Controller input crash fix.

### DIFF
--- a/CS483/CS483/Kartaclysm/Services/IO/PlayerInputMapping.cpp
+++ b/CS483/CS483/Kartaclysm/Services/IO/PlayerInputMapping.cpp
@@ -340,7 +340,7 @@ namespace Kartaclysm
 			}
 			else
 			{
-				AssignInput(i, GetFirstAvailableInput());
+				//AssignInput(i, GetFirstAvailableInput());
 			}
 		}
 
@@ -410,7 +410,7 @@ namespace Kartaclysm
 			{
 				if (!m_bRaceMode)
 				{
-					AssignInput(iPlayerWithoutInput, iGLFWJoystick);
+					//AssignInput(iPlayerWithoutInput, iGLFWJoystick);
 				}
 				else
 				{
@@ -426,7 +426,7 @@ namespace Kartaclysm
 				int iKeyboardPlayer = PlayerUsingInput(GLFW_JOYSTICK_LAST + 1);
 				if (iKeyboardPlayer >= 0 && !m_bRaceMode)
 				{
-					AssignInput(iKeyboardPlayer, iGLFWJoystick);
+					//AssignInput(iKeyboardPlayer, iGLFWJoystick);
 				}
 			}
 		}
@@ -438,7 +438,7 @@ namespace Kartaclysm
 			{
 				if (!m_bRaceMode)
 				{
-					AssignInput(iPlayerUsingInput, GetFirstAvailableInput());
+					//AssignInput(iPlayerUsingInput, GetFirstAvailableInput());
 				}
 				else
 				{


### PR DESCRIPTION
Removing extra controller assignments since all four players need to be assigned from the start for handling the player selection screen.