### PR TITLE
Load sound effects on a separate thread

### DIFF
--- a/CS483/CS483/CS483.vcxproj
+++ b/CS483/CS483/CS483.vcxproj
@@ -415,7 +415,6 @@
     <Xml Include="Kartaclysm\Data\Menus\PlayerSelectionMenu\player_0\stats\speed_4.xml" />
     <Xml Include="Kartaclysm\Data\Menus\PlayerSelectionMenu\player_0\stats\speed_5.xml" />
     <Xml Include="Kartaclysm\Data\Menus\PlayerSelectionMenu\player_0\stats\speed_6.xml" />
-    <Xml Include="Kartaclysm\Data\Menus\PlayerSelectionMenu\player_0\stats_0.xml" />
     <Xml Include="Kartaclysm\Data\Menus\PlayerSelectionMenu\player_1\description_boxes_1.xml" />
     <Xml Include="Kartaclysm\Data\Menus\PlayerSelectionMenu\player_1\driver_abilities_cleopapa_1.xml" />
     <Xml Include="Kartaclysm\Data\Menus\PlayerSelectionMenu\player_1\driver_abilities_clockmaker_1.xml" />

--- a/CS483/CS483/Kartaclysm/Data/DevConfig/Preload.xml
+++ b/CS483/CS483/Kartaclysm/Data/DevConfig/Preload.xml
@@ -80,6 +80,7 @@
     <Sprite path="Assets/Hud/Positions/position_4.mtl" mtl="position_4"/>
 
     <!-- Menus -->
+    <Sprite path="Assets/Menus/Background/background.mtl" mtl="background"/>
     <Sprite path="Assets/Menus/MainMenu/loading_message.mtl" mtl="loading_message"/>
     <Sprite path="Assets/Menus/MainMenu/press_start.mtl" mtl="press_start"/>
     <Sprite path="Assets/Menus/MainMenu/title_image.mtl" mtl="title_image"/>

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateMainMenu.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateMainMenu.cpp
@@ -69,14 +69,14 @@ void Kartaclysm::StateMainMenu::Update(const float p_fDelta)
 			{
 				m_bPreloadCalled = true;
 
-				std::thread mLoadSfxThread(
+				std::thread thrLoadSoundEffects(
 					&HeatStroke::AudioPlayer::PreloadSoundEffects,
 					HeatStroke::AudioPlayer::Instance(),
 					"CS483/CS483/Kartaclysm/Data/DevConfig/Preload.xml");
 
 				HeatStroke::ModelManager::Instance()->Preload("CS483/CS483/Kartaclysm/Data/DevConfig/Preload.xml");
 				
-				mLoadSfxThread.join(); // blocks execution until thread ends
+				thrLoadSoundEffects.join(); // blocks execution until thread ends
 
 				m_pGameObjectManager->DestroyGameObject(m_pGameObjectManager->GetGameObject("LoadingMessage"));
 				m_pGameObjectManager->CreateGameObject("CS483/CS483/Kartaclysm/Data/Menus/MainMenu/press_start.xml", "PressStart");

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateMainMenu.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateMainMenu.cpp
@@ -68,8 +68,15 @@ void Kartaclysm::StateMainMenu::Update(const float p_fDelta)
 			if (m_bRenderedOnce)
 			{
 				m_bPreloadCalled = true;
+
+				std::thread mLoadSfxThread(
+					&HeatStroke::AudioPlayer::PreloadSoundEffects,
+					HeatStroke::AudioPlayer::Instance(),
+					"CS483/CS483/Kartaclysm/Data/DevConfig/Preload.xml");
+
 				HeatStroke::ModelManager::Instance()->Preload("CS483/CS483/Kartaclysm/Data/DevConfig/Preload.xml");
-				HeatStroke::AudioPlayer::Instance()->PreloadSoundEffects("CS483/CS483/Kartaclysm/Data/DevConfig/Preload.xml");
+				
+				mLoadSfxThread.join(); // blocks execution until thread ends
 
 				m_pGameObjectManager->DestroyGameObject(m_pGameObjectManager->GetGameObject("LoadingMessage"));
 				m_pGameObjectManager->CreateGameObject("CS483/CS483/Kartaclysm/Data/Menus/MainMenu/press_start.xml", "PressStart");

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateMainMenu.h
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateMainMenu.h
@@ -8,6 +8,8 @@
 #ifndef STATE_MAIN_MENU_H
 #define STATE_MAIN_MENU_H
 
+#include <thread>
+
 #include "ComponentOrthographicCamera.h"
 #include "ComponentSprite.h"
 #include "ComponentPerspectiveCamera.h"


### PR DESCRIPTION
Surprisingly quick fix to load times. Doesn't work for ModelManager because of threading complications with the OpenGL state, but works fine with sound effects. 

For my few benchmark tests on VS 2015, it reduced the load time of this block by 25%
Release: 5s -> 3s
Debug: 15s -> 12s