### PR TITLE
Bugfix/cooldown event

### DIFF
--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateCountdown.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateCountdown.cpp
@@ -51,8 +51,7 @@ void Kartaclysm::StateCountdown::Update(const float p_fDelta)
 			pCountdownEvent->SetIntParameter("Disable", 0);
 			for (int i = 0; i < m_iPlayerCount; i++)
 			{
-				// FIXME - this causes a crash when running in debug in VS 2015
-				pHudEvent->SetFloatParameter("Player" + std::to_string(i), (m_vGainsBoost[i] ? 1.3f : 0.0f));
+				pCountdownEvent->SetFloatParameter("Player" + std::to_string(i), (m_vGainsBoost[i] ? 1.3f : 0.0f));
 			}
 			HeatStroke::EventManager::Instance()->TriggerEvent(pCountdownEvent);
 

--- a/HeatStroke/Services/Events/EventManager.cpp
+++ b/HeatStroke/Services/Events/EventManager.cpp
@@ -152,5 +152,6 @@ namespace HeatStroke
 
 		// Everyone has seen the event at this point, so we can clean it up.
 		delete p_pEvent;
+		p_pEvent = nullptr;
 	}
 }


### PR DESCRIPTION
Setting float parameter on triggered (read: deleted) event was causing errors during countdown. Setting triggered events to nullptr will hopefully prevent cases like this in the future.

(Tested cooldown boost and it works with this fix. I believe it worked before too...)