### PR TITLE
Quick fix for spacing between text on race result screen

### DIFF
--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRaceCompleteMenu.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRaceCompleteMenu.cpp
@@ -215,8 +215,11 @@ void Kartaclysm::StateRaceCompleteMenu::PopulateRaceResultsList(const std::map<s
 	for (int i = 0; i < iNumRacers; ++i)
 	{
 		std::string strIndex = std::to_string(i);
+
 		std::string strRacerId = p_mRaceResults.at("racerId" + strIndex);
-		std::string strRacerTime = Common::TimeStringFromFloat(std::stof(p_mRaceResults.at("racerTime" + strIndex)));
+		for (unsigned int uiPadding = (strRacerId.at(0) == 'P' ? 7 : 2); uiPadding > 0; --uiPadding) strRacerId += " ";
+
+		std::string strRacerTime = Common::TimeStringFromFloat(std::stof(p_mRaceResults.at("racerTime" + strIndex))) + "  ";
 
 		std::string strRacerPoints = "";
 		auto find = p_mRaceResults.find("racerPoints" + strIndex);


### PR DESCRIPTION
Add some padding space between the racer id and the race time to compensate the size difference between "AI_racerX" and "PlayerX".