### PR TITLE
Fix ability countdown and multiple debug messages

### DIFF
--- a/CS483/CS483/Kartaclysm/Components/Abilities/ComponentAbilityConditions.cpp
+++ b/CS483/CS483/Kartaclysm/Components/Abilities/ComponentAbilityConditions.cpp
@@ -20,7 +20,7 @@ namespace Kartaclysm
 		m_pGameObject(p_pGameObject),
 		m_strEventName(p_strAbility),
 		m_fMaxCooldown(p_fCooldown),
-		m_fCurrentCooldown(p_fCooldown > 0.0f ? p_fCooldown : p_fCooldown + 3.0f), // beginning race countdown
+		m_fCurrentCooldown(p_fCooldown <= 0.0f ? p_fCooldown : p_fCooldown + 3.0f), // beginning race countdown
 		m_iMaxCharges(p_iMaxCharges),
 		m_iCurrentCharges(p_iStartCharges),
 		m_bSpecial(true),

--- a/CS483/CS483/Kartaclysm/Components/ComponentKartController.cpp
+++ b/CS483/CS483/Kartaclysm/Components/ComponentKartController.cpp
@@ -818,13 +818,13 @@ namespace Kartaclysm
 		p_pEvent->GetOptionalFloatParameter("Power", power, power);
 		p_pEvent->GetOptionalFloatParameter("Duration", duration, duration);
 
-#ifdef _DEBUG
-		printf("KartController: Ability %s from %s targetting %s\n", 
-			ability.c_str(), originator.c_str(), target == "" ? "self" : target.c_str());
-#endif
-
 		if (target.compare(m_pGameObject->GetGUID()) == 0)
 		{
+#ifdef _DEBUG
+			printf("KartController: Ability %s from %s targetting %s\n",
+				ability.c_str(), originator.c_str(), target == "" ? "self" : target.c_str());
+#endif
+
 			// See if an ability is waiting to negate an attack
 			if (m_strHitCallback != "")
 			{
@@ -866,6 +866,11 @@ namespace Kartaclysm
 		}
 		else if (originator.compare(m_pGameObject->GetGUID()) == 0)
 		{
+#ifdef _DEBUG
+			printf("KartController: Ability %s from %s targetting %s\n",
+				ability.c_str(), originator.c_str(), target == "" ? "self" : target.c_str());
+#endif
+
 			if (ability.compare("Boost") == 0)
 			{
 				HeatStroke::AudioPlayer::Instance()->PlaySoundEffect("Assets/Sounds/speedster_boost.flac");

--- a/CS483/CS483/Kartaclysm/Components/ComponentKartController.cpp
+++ b/CS483/CS483/Kartaclysm/Components/ComponentKartController.cpp
@@ -822,7 +822,7 @@ namespace Kartaclysm
 		{
 #ifdef _DEBUG
 			printf("KartController: Ability %s from %s targetting %s\n",
-				ability.c_str(), originator.c_str(), target == "" ? "self" : target.c_str());
+				ability.c_str(), originator.c_str(), target.c_str());
 #endif
 
 			// See if an ability is waiting to negate an attack
@@ -867,8 +867,11 @@ namespace Kartaclysm
 		else if (originator.compare(m_pGameObject->GetGUID()) == 0)
 		{
 #ifdef _DEBUG
-			printf("KartController: Ability %s from %s targetting %s\n",
-				ability.c_str(), originator.c_str(), target == "" ? "self" : target.c_str());
+			if (target == "")
+			{
+				printf("KartController: Ability %s from %s targetting %s\n",
+					ability.c_str(), originator.c_str(), "self");
+			}
 #endif
 
 			if (ability.compare("Boost") == 0)


### PR DESCRIPTION
Wrong relationship operator allowed abilities to be activated during the beginning countdown.

Also did a minor fix to reduce the times debug messages are shown for ability activations.