### PR TITLE
Change OpenGL default color

### DIFF
--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateModeSelectionMenu.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateModeSelectionMenu.cpp
@@ -71,6 +71,7 @@ void Kartaclysm::StateModeSelectionMenu::Update(const float p_fDelta)
 			m_pStateMachine->Push(STATE_TOURNAMENT, mContextParameters);
 			break;
 		case 2:
+			mContextParameters["background"] = "CS483/CS483/Kartaclysm/Data/Menus/background.xml";
 			m_pStateMachine->Push(STATE_OPTIONS_MENU, mContextParameters);
 			break;
 		}

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateOptionsMenu.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateOptionsMenu.cpp
@@ -44,6 +44,14 @@ void Kartaclysm::StateOptionsMenu::Enter(const std::map<std::string, std::string
 	m_pGameObjectManager->RegisterComponentFactory("GOC_PerspectiveCamera", HeatStroke::ComponentPerspectiveCamera::CreateComponent);
 	m_pGameObjectManager->RegisterComponentFactory("GOC_MenuSlider", ComponentMenuSlider::CreateComponent);
 
+	// Get background image if specified
+	find = p_mContextParameters.find("background");
+	if (find != p_mContextParameters.end())
+	{
+		HeatStroke::GameObject* pBackground = m_pGameObjectManager->CreateGameObject(find->second);
+		pBackground->GetTransform().TranslateXYZ(-200.0f, 0.0f, 0.0f);
+	}
+
 	m_pGameObjectManager->CreateGameObject("CS483/CS483/Kartaclysm/Data/Camera/camera_overlay.xml");
 	m_pGameObjectManager->CreateGameObject("CS483/CS483/Kartaclysm/Data/Menus/OptionsMenu/options_selection.xml");
 	m_pCurrentHighlight = m_pGameObjectManager->CreateGameObject("CS483/CS483/Kartaclysm/Data/Menus/OptionsMenu/options_highlight_music.xml");

--- a/CS483/CS483/Kartaclysm/main.cpp
+++ b/CS483/CS483/Kartaclysm/main.cpp
@@ -11,5 +11,5 @@
 int main(int argc, char* argv[])
 {
 	Kartaclysm::KartGame *game = new Kartaclysm::KartGame();
-	return game->Run("Kartaclysm");
+	return game->Run("Kartaclysm", glm::vec4(0.43f, 0.48f, 0.88f, 0.0f));
 }

--- a/HeatStroke/Common/Game.cpp
+++ b/HeatStroke/Common/Game.cpp
@@ -44,7 +44,7 @@ Game::~Game()
 // Starts (and runs) the main game loop. Does not return until application
 // shuts down.
 //------------------------------------------------------------------------------
-int Game::Run(const char* p_strAppName, int p_iWindowWidth, int p_iWindowHeight)
+int Game::Run(const char* p_strAppName, glm::vec4 p_vDefaultColor, int p_iWindowWidth, int p_iWindowHeight)
 {
 	float t;
 
@@ -99,8 +99,8 @@ int Game::Run(const char* p_strAppName, int p_iWindowWidth, int p_iWindowHeight)
 	{
 		t = static_cast<float>(glfwGetTime());
 
-		// Clear color buffer to black
-		glClearColor( 0.5f, 0.5f, 0.5f, 0.0f );
+		// Clear color buffer to default color
+		glClearColor(p_vDefaultColor.r, p_vDefaultColor.g, p_vDefaultColor.b, p_vDefaultColor.a);
 		glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
 
 		float fDelta = (float)t - m_fFrameTime;

--- a/HeatStroke/Common/Game.h
+++ b/HeatStroke/Common/Game.h
@@ -37,6 +37,7 @@ namespace HeatStroke
 		virtual ~Game();
 
 		int Run(const char* p_strAppName = "HeatStroke::Game",
+				glm::vec4 p_vDefaultColor = glm::vec4(0.5f, 0.5f, 0.5f, 0.0f),
 				int p_iWindowWidth = 1280,
 				int p_iWindowHeight = 720);
 


### PR DESCRIPTION
Change default pixel color to sky blue as a quick way to brighten the sky during a race.

I also noticed the Options Menu did not have a background when accessed from the Main Menu, so I gave it the Main Menu background instead.