### PR TITLE
Fix issue with backtracking to Player Select from Track Select

### DIFF
--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StatePlayerSelectionMenu.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StatePlayerSelectionMenu.cpp
@@ -85,6 +85,7 @@ Kartaclysm::StatePlayerSelectionMenu::StatePlayerSelectionMenu()
 	GameplayState("Player Selection"),
 	m_pGameObjectManager(nullptr),
 	m_bSuspended(true),
+	m_strMode(""),
 	m_uiNumPlayers(0)
 {
 }
@@ -96,7 +97,20 @@ Kartaclysm::StatePlayerSelectionMenu::~StatePlayerSelectionMenu()
 void Kartaclysm::StatePlayerSelectionMenu::Enter(const std::map<std::string, std::string>& p_mContextParameters)
 {
 	m_mContextParameters = p_mContextParameters;
+	m_strMode = p_mContextParameters.at("Mode");
 	Initialize();
+}
+
+void Kartaclysm::StatePlayerSelectionMenu::Suspend(const int p_iNewState)
+{
+	Exit();
+}
+
+void Kartaclysm::StatePlayerSelectionMenu::Unsuspend(const int p_iPrevState)
+{
+	std::map<std::string, std::string> mContextParameters;
+	mContextParameters["Mode"] = m_strMode;
+	Enter(mContextParameters);
 }
 
 void Kartaclysm::StatePlayerSelectionMenu::Update(const float p_fDelta)

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StatePlayerSelectionMenu.h
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StatePlayerSelectionMenu.h
@@ -31,8 +31,8 @@ namespace Kartaclysm
 		virtual ~StatePlayerSelectionMenu();
 
 		void Enter(const std::map<std::string, std::string>& p_mContextParameters);
-		void Suspend(const int p_iNewState)			{ Exit(); }
-		void Unsuspend(const int p_iPrevState)		{ Enter(m_mContextParameters); }
+		void Suspend(const int p_iNewState);
+		void Unsuspend(const int p_iPrevState);
 		void Update(const float p_fDelta);
 		void PreRender();
 		void Exit();
@@ -97,6 +97,7 @@ namespace Kartaclysm
 		std::vector<std::string> m_vKarts;
 
 		std::map<std::string, std::string> m_mContextParameters;
+		std::string m_strMode;
 
 		unsigned int m_uiNumPlayers;
 		PerPlayerMenuState m_mPerPlayerMenuState[4];


### PR DESCRIPTION
Context parameters are not reset when cancelling from Track Select Screen back to Player Select Menu, leading to leftover players in a race.

Previous Issue:
1. Select Singe Race mode (does not work in Tournament as there is no Track Select)
2. Proceed to Track Select with 2+ players
3. Return to previous menu (do not start the race)
4. Proceed through Track Select and into race with less players
5. Extra players from step 2 still stored in context parameters and loaded in race