### PR TITLE
Hotfix/broken tournament

### DIFF
--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateMainMenu.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateMainMenu.cpp
@@ -119,6 +119,7 @@ void Kartaclysm::StateMainMenu::Update(const float p_fDelta)
 	}
 	else if (bConfirm)
 	{
+		m_pStateMachine->Pop();
 		m_pStateMachine->Push(STATE_MODE_SELECTION_MENU);
 	}
 }

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateModeSelectionMenu.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateModeSelectionMenu.cpp
@@ -67,6 +67,10 @@ void Kartaclysm::StateModeSelectionMenu::Update(const float p_fDelta)
 			m_pStateMachine->Push(STATE_PLAYER_SELECTION_MENU, mContextParameters);
 			break;
 		case 1:
+			while (!m_pStateMachine->empty())
+			{
+				m_pStateMachine->Pop();
+			}
 			mContextParameters["Mode"] = "Tournament";
 			m_pStateMachine->Push(STATE_TOURNAMENT, mContextParameters);
 			break;

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StatePlayerSelectionMenu.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StatePlayerSelectionMenu.cpp
@@ -629,10 +629,7 @@ void Kartaclysm::StatePlayerSelectionMenu::GoToTrackSelectionState()
 	}
 	else
 	{
-		while (!m_pStateMachine->empty())
-		{
-			m_pStateMachine->Pop();
-		}
+		m_pStateMachine->Pop();
 		m_pStateMachine->Push(STATE_RACING, m_mContextParameters);
 	}
 }

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRacing.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRacing.cpp
@@ -36,7 +36,7 @@ Kartaclysm::StateRacing::~StateRacing()
 
 void Kartaclysm::StateRacing::Enter(const std::map<std::string, std::string>& p_mContextParameters)
 {
-	assert(m_pStateMachine->size() == 1); // this should be the only state on the stack
+	assert(m_pStateMachine->size() <= 2); // this and tournament should be the only states on the stack
 	m_bSuspended = false;
 	m_fTimeRemaining = -1.0f;
 	m_vRaceResults.clear();

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRacing.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateRacing.cpp
@@ -36,7 +36,10 @@ Kartaclysm::StateRacing::~StateRacing()
 
 void Kartaclysm::StateRacing::Enter(const std::map<std::string, std::string>& p_mContextParameters)
 {
-	assert(m_pStateMachine->size() <= 2); // this and tournament should be the only states on the stack
+#ifdef _DEBUG
+	assert(m_pStateMachine->size() == (p_mContextParameters.at("Mode") == "Tournament" ? 2 : 1));
+#endif
+
 	m_bSuspended = false;
 	m_fTimeRemaining = -1.0f;
 	m_vRaceResults.clear();

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateTournament.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateTournament.cpp
@@ -15,6 +15,7 @@ Kartaclysm::StateTournament::StateTournament()
 	m_bReadyForNextRace(false),
 	m_bFinished(false),
 	m_bCongrats(false),
+	m_bReturnedFromPlayerSelect(false),
 	m_uiRaceCount(0),
 	m_mContextParams(),
 	m_mRacerRankings()
@@ -53,6 +54,17 @@ void Kartaclysm::StateTournament::Enter(const std::map<std::string, std::string>
 	m_pStateMachine->Push(STATE_PLAYER_SELECTION_MENU, m_mContextParams);
 }
 
+void Kartaclysm::StateTournament::Suspend(const int p_iNewState)
+{
+	m_bSuspended = true;
+}
+
+void Kartaclysm::StateTournament::Unsuspend(const int p_iPrevState)
+{
+	m_bSuspended = false;
+	m_bReturnedFromPlayerSelect = (p_iPrevState == STATE_PLAYER_SELECTION_MENU);
+}
+
 void Kartaclysm::StateTournament::Update(const float p_fDelta)
 {
 	if (m_bSuspended) return;
@@ -83,13 +95,13 @@ void Kartaclysm::StateTournament::Update(const float p_fDelta)
 	else
 	{
 		// Quit tournament early or some other problem
-
 		DatabaseManager::Instance()->CancelTournament();
 		m_pStateMachine->Pop();
 		if (m_pStateMachine->empty())
 		{
-			m_pStateMachine->Push(STATE_MAIN_MENU);
+			m_pStateMachine->Push(m_bReturnedFromPlayerSelect ? STATE_MODE_SELECTION_MENU : STATE_MAIN_MENU);
 		}
+		m_bReturnedFromPlayerSelect = false;
 	}
 }
 

--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateTournament.h
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StateTournament.h
@@ -27,8 +27,8 @@ namespace Kartaclysm
 		virtual ~StateTournament();
 
 		void Enter(const std::map<std::string, std::string>& p_mContextParameters);
-		void Suspend(const int p_iNewState)		{ m_bSuspended = true; }
-		void Unsuspend(const int p_iPrevState)	{ m_bSuspended = false; }
+		void Suspend(const int p_iNewState);
+		void Unsuspend(const int p_iPrevState);
 		void Update(const float p_fDelta);
 		void PreRender() {}
 		void Exit();
@@ -51,6 +51,7 @@ namespace Kartaclysm
 		bool m_bReadyForNextRace;
 		bool m_bFinished;
 		bool m_bCongrats;
+		bool m_bReturnedFromPlayerSelect;
 		unsigned int m_uiRaceCount;
 		std::vector<std::string> m_vTracks;
 		std::map<std::string, std::string> m_mContextParams;


### PR DESCRIPTION
Fixes issue with tournament mode ending after one race because the tournament state was popped. To avoid multiple attempts to reconnect to the database (joining tournament -> cancelling to main menu), the main menu state cannot be returned to except after joining a race