### PR TITLE
Reduce pre-render startup time with database thread

### DIFF
--- a/CS483/CS483/Kartaclysm/KartGame.h
+++ b/CS483/CS483/Kartaclysm/KartGame.h
@@ -36,6 +36,7 @@
 #include "FontManager.h"
 #include "MySQLConnector.h"
 #include "DatabaseManager.h"
+#include <thread>
 
 namespace Kartaclysm
 {

--- a/CS483/CS483/Kartaclysm/Services/MySQL/DatabaseManager.cpp
+++ b/CS483/CS483/Kartaclysm/Services/MySQL/DatabaseManager.cpp
@@ -36,7 +36,6 @@ Kartaclysm::DatabaseManager::DatabaseManager()
 	m_uiTotalTournamentRaces(0),
 	m_vTournamentRaceIds()
 {
-	TryToConnect();
 }
 
 Kartaclysm::DatabaseManager::~DatabaseManager()


### PR DESCRIPTION
Reduces time before game starts rendering by connecting to the database on a separate thread. Saves ~0.5s (1.5 -> 1.0s) by loading sprites at the same time as trying to connect.

The database connection and fastest times query are now the bottlenecks for both load times (pre- and post- render). It would take a considerable redesign to speed up times any further