### PR TITLE
Fix issues with default enums when adding player

### DIFF
--- a/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StatePlayerSelectionMenu.cpp
+++ b/CS483/CS483/Kartaclysm/StateMachine/Gameplay/StatePlayerSelectionMenu.cpp
@@ -547,6 +547,8 @@ void Kartaclysm::StatePlayerSelectionMenu::AddPlayer(const unsigned int p_uiPlay
 		m_mPerPlayerMenuState[p_uiPlayerNum].pPressStartToJoin = nullptr;
 	}
 
+	m_mPerPlayerMenuState[p_uiPlayerNum].eCurrentSelection = SELECTION_DRIVER;
+	m_mPerPlayerMenuState[p_uiPlayerNum].eSelectedControl = CONTROL_HUMAN;
 	m_mPerPlayerMenuState[p_uiPlayerNum].pControlSelection = m_pGameObjectManager->CreateGameObject("CS483/CS483/Kartaclysm/Data/Menus/PlayerSelectionMenu/player_" + strPlayerNum + "/control_selection_human_" + strPlayerNum + ".xml");
 	m_mPerPlayerMenuState[p_uiPlayerNum].pDriverSelection = m_pGameObjectManager->CreateGameObject("CS483/CS483/Kartaclysm/Data/Menus/PlayerSelectionMenu/player_" + strPlayerNum + "/driver_selection_cleopapa_" + strPlayerNum + ".xml");
 	m_mPerPlayerMenuState[p_uiPlayerNum].pKartSelection = m_pGameObjectManager->CreateGameObject("CS483/CS483/Kartaclysm/Data/Menus/PlayerSelectionMenu/player_" + strPlayerNum + "/kart_selection_speedster_" + strPlayerNum + ".xml");


### PR DESCRIPTION
Fix issues mentioned in pull request #178 comment that were not addressed before merging.

"When a player joins, the graphics say they are highlighting the driver select but they cannot press up. When they press down, it stays on driver select and then you can press up. The coded default is human/bot control, but the graphic default is driver select."
-Caused by eSelectedControl not being set back to CONTROL_HUMAN when rejoining

"I can't explain why, but joining another player, changing them to bot, and then cancelling them permanently increases m_uiNumPlayers by 1 and permanently decreases m_uiNumAIPlayers by 1 (resulting in underflow to 65million). This is repeatable too."
-Caused by eCurrentSelection not being reset to SELECTION_DRIVER when rejoining