### PR TITLE
Reducing the hitbox for the clockbomb pre-explosion

### DIFF
--- a/CS483/CS483/Kartaclysm/Data/Abilities/projectile_clock.xml
+++ b/CS483/CS483/Kartaclysm/Data/Abilities/projectile_clock.xml
@@ -15,7 +15,7 @@
 
     <GOC_SphereCollider>
       <Offset x="0" y="0" z="0" />
-      <Sphere radius="1.0" />
+      <Sphere radius="0.2" />
       <Physics applies="false" />
     </GOC_SphereCollider>
 


### PR DESCRIPTION
The hitbox is unfairly huge (twice the bowling ball) for just the thrown object. Explosion radius unchanged.